### PR TITLE
수정

### DIFF
--- a/src/main/java/com/mes/mesBackend/config/MapperConfig.java
+++ b/src/main/java/com/mes/mesBackend/config/MapperConfig.java
@@ -38,6 +38,7 @@ public class MapperConfig {
         modelMapper.addConverter(toContractItemResponse);
         modelMapper.addConverter(contractToProduceOrderConverter);
         modelMapper.addConverter(contractItemToProduceOrderConverter);
+        modelMapper.addConverter(equipmentToResponse);
 
         return modelMapper;
     }
@@ -257,6 +258,17 @@ public class MapperConfig {
             produceOrder.setItemName(contractItem.getItem().getItemName());
             produceOrder.setAmount(contractItem.getAmount());
             return produceOrder;
+        }
+    };
+
+    Converter<Equipment, EquipmentResponse> equipmentToResponse = new Converter<Equipment, EquipmentResponse>() {
+        @Override
+        public EquipmentResponse convert(MappingContext<Equipment, EquipmentResponse> context) {
+            ModelMapper modelMapper = new ModelMapper();
+            Equipment equipment = context.getSource();
+            EquipmentResponse response = modelMapper.map(equipment, EquipmentResponse.class);
+            response.setEquipmentType(equipment.getWorkLine().getWorkLineName());
+            return response;
         }
     };
 }

--- a/src/main/java/com/mes/mesBackend/controller/EquipmentCheckController.java
+++ b/src/main/java/com/mes/mesBackend/controller/EquipmentCheckController.java
@@ -49,12 +49,12 @@ public class EquipmentCheckController {
             description = "검색조건: 설비유형, 점검유형(보류), 작업기간 fromDate~toDate"
     )
     public ResponseEntity<List<EquipmentCheckResponse>> getEquipmentChecks(
-            @RequestParam(required = false) @Parameter(description = "설비유형") String equipmentType,
+            @RequestParam(required = false) @Parameter(description = "설비유형(작업라인 id)") Long workLineId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "작업기간 fromDate") LocalDate fromDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "작업기간 toDate") LocalDate toDate,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) {
-        List<EquipmentCheckResponse> equipmentChecks = equipmentCheckService.getEquipmentChecks(equipmentType, fromDate, toDate);
+        List<EquipmentCheckResponse> equipmentChecks = equipmentCheckService.getEquipmentChecks(workLineId, fromDate, toDate);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getEquipmentChecks.");
         return new ResponseEntity<>(equipmentChecks, HttpStatus.OK);

--- a/src/main/java/com/mes/mesBackend/controller/EquipmentRepairHistoryController.java
+++ b/src/main/java/com/mes/mesBackend/controller/EquipmentRepairHistoryController.java
@@ -1,0 +1,52 @@
+package com.mes.mesBackend.controller;
+
+import com.mes.mesBackend.dto.response.EquipmentRepairHistoryResponse;
+import com.mes.mesBackend.logger.CustomLogger;
+import com.mes.mesBackend.logger.LogService;
+import com.mes.mesBackend.logger.MongoLogger;
+import com.mes.mesBackend.service.EquipmentBreakdownService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+// 17-3. 설비 수리내역 조회
+@Tag(name = "equipment-repair-history", description = "17-3. 설비 수리내역 조회 API")
+@RequestMapping("/equipment-repair-histories")
+@RestController
+@SecurityRequirement(name = "Authorization")
+@RequiredArgsConstructor
+public class EquipmentRepairHistoryController {
+    private final EquipmentBreakdownService equipmentBreakdownService;
+    private final LogService logService;
+    private final Logger logger = LoggerFactory.getLogger(EquipmentBreakdownRepairController.class);
+    private CustomLogger cLogger;
+
+    // 설비 수리내역 리스트 조회, 검색조건: 작업장 id, 설비유형, 수리항목, 작업기간 fromDate~toDate
+    @Operation(summary = "설비 수리내역 리스트 조회", description = "검색조건: 작업장 id, 설비유형, 수리항목, 작업기간 fromDate~toDate")
+    @GetMapping
+    @ResponseBody
+    public ResponseEntity<List<EquipmentRepairHistoryResponse>> getEquipmentRepairHistories(
+            @RequestParam(required = false) @Parameter(description = "작업장 id") Long workCenterId,
+            @RequestParam(required = false) @Parameter(description = "설비유형") String equipmentType,
+            @RequestParam(required = false) @Parameter(description = "수리항목") String repairItem,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "작업기간 fromDate") LocalDate fromDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "작업기간 toDate") LocalDate toDate,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) {
+        List<EquipmentRepairHistoryResponse> repairHistoryResponses = equipmentBreakdownService.getEquipmentRepairHistories(workCenterId, equipmentType, repairItem, fromDate, toDate);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getEquipmentRepairHistories.");
+        return new ResponseEntity<>(repairHistoryResponses, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/mes/mesBackend/controller/RepairCodeController.java
+++ b/src/main/java/com/mes/mesBackend/controller/RepairCodeController.java
@@ -1,0 +1,132 @@
+package com.mes.mesBackend.controller;
+
+import com.mes.mesBackend.dto.request.RepairCodeRequest;
+import com.mes.mesBackend.dto.response.RepairCodeResponse;
+import com.mes.mesBackend.exception.NotFoundException;
+import com.mes.mesBackend.logger.CustomLogger;
+import com.mes.mesBackend.logger.LogService;
+import com.mes.mesBackend.logger.MongoLogger;
+import com.mes.mesBackend.service.RepairCodeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+// 수리코드
+@Tag(name = "repair-code", description = "수리코드 API")
+@RequestMapping("/repair-codes")
+@RestController
+@SecurityRequirement(name = "Authorization")
+@RequiredArgsConstructor
+public class RepairCodeController {
+
+    private final RepairCodeService repairCodeService;
+    private final LogService logService;
+    private final Logger logger = LoggerFactory.getLogger(RepairCodeController.class);
+    private CustomLogger cLogger;
+
+    // 수리코드 생성
+    @PostMapping
+    @ResponseBody
+    @Operation(summary = "수리코드 생성")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "success"),
+                    @ApiResponse(responseCode = "400", description = "bad request")
+            }
+    )
+    public ResponseEntity<RepairCodeResponse> createRepairCode(
+            @RequestBody @Valid RepairCodeRequest repairCodeRequest,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) {
+        RepairCodeResponse repairCode = repairCodeService.createRepairCode(repairCodeRequest);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + repairCode.getId() + " from createRepairCode.");
+        return new ResponseEntity<>(repairCode, HttpStatus.OK);
+    }
+
+    // 수리코드 단일 조회
+    @GetMapping("/{id}")
+    @ResponseBody
+    @Operation(summary = "수리코드 단일 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "success"),
+                    @ApiResponse(responseCode = "404", description = "not found resource"),
+            }
+    )
+    public ResponseEntity<RepairCodeResponse> getRepairCode(
+            @PathVariable Long id,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException {
+        RepairCodeResponse repairCode = repairCodeService.getRepairCode(id);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the " + repairCode.getId() + " from getRepairCode.");
+        return new ResponseEntity<>(repairCode, HttpStatus.OK);
+    }
+
+    // 수리코드 전체 조회
+    @GetMapping
+    @ResponseBody
+    @Operation(summary = "수리코드 전체 조회")
+    public ResponseEntity<List<RepairCodeResponse>> getRepairCodes(
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) {
+        List<RepairCodeResponse> repairCodes = repairCodeService.getRepairCodes();
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getRepairCodes.");
+        return new ResponseEntity<>(repairCodes, HttpStatus.OK);
+    }
+
+    // 수리코드 수정
+    @PatchMapping("/{id}")
+    @ResponseBody
+    @Operation(summary = "수리코드 수정")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "success"),
+                    @ApiResponse(responseCode = "400", description = "bad request")
+            }
+    )
+    public ResponseEntity<RepairCodeResponse> updateRepairCode(
+            @PathVariable Long id,
+            @RequestBody @Valid RepairCodeRequest repairCodeRequest,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException {
+        RepairCodeResponse repairCode = repairCodeService.updateRepairCode(id, repairCodeRequest);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is modified the " + repairCode.getId() + " from updateRepairCode.");
+        return new ResponseEntity<>(repairCode, HttpStatus.OK);
+    }
+
+    // 수리코드 삭제
+    @DeleteMapping("/{id}")
+    @ResponseBody
+    @Operation(summary = "수리코드 삭제")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "204", description = "no content"),
+                    @ApiResponse(responseCode = "404", description = "not found resource")
+            }
+    )
+    public ResponseEntity deleteRepairCode(
+            @PathVariable Long id,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException {
+        repairCodeService.deleteRepairCode(id);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + id + " from deleteRepairCode.");
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/mes/mesBackend/dto/request/RepairCodeRequest.java
+++ b/src/main/java/com/mes/mesBackend/dto/request/RepairCodeRequest.java
@@ -8,11 +8,11 @@ import javax.validation.constraints.NotBlank;
 
 import static com.mes.mesBackend.exception.Message.NOT_EMPTY;
 
-// 17-2. 설비고장 수리내역 등록 수리항목
+// 수리코드
 @Getter
 @Setter
-@Schema(description = "수리항목")
-public class RepairItemRequest {
+@Schema(description = "수리코드")
+public class RepairCodeRequest {
     @Schema(description = "수리코드")
     @NotBlank(message = NOT_EMPTY)
     String repairCode;

--- a/src/main/java/com/mes/mesBackend/dto/response/EquipmentRepairHistoryResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/EquipmentRepairHistoryResponse.java
@@ -1,0 +1,4 @@
+package com.mes.mesBackend.dto.response;
+
+public class EquipmentRepairHistoryResponse {
+}

--- a/src/main/java/com/mes/mesBackend/dto/response/EquipmentResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/EquipmentResponse.java
@@ -1,15 +1,19 @@
 package com.mes.mesBackend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 @Getter
 @Setter
 @Schema(description = "설비")
+@JsonInclude(NON_NULL)
 public class EquipmentResponse {
     @Schema(description = "고유아이디")
     Long id;

--- a/src/main/java/com/mes/mesBackend/dto/response/RepairCodeResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/RepairCodeResponse.java
@@ -1,0 +1,20 @@
+package com.mes.mesBackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+// 수리코드
+@Getter
+@Setter
+@Schema(description = "수리코드")
+public class RepairCodeResponse {
+    @Schema(description = "고유아이디")
+    Long id;
+
+    @Schema(description = "수리코드")
+    String repairCode;
+
+    @Schema(description = "수리내용")
+    String repairContent;
+}

--- a/src/main/java/com/mes/mesBackend/dto/response/RepairWorkerResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/RepairWorkerResponse.java
@@ -7,15 +7,15 @@ import lombok.Setter;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
-// 17-2. 설비고장 수리내역 등록 수리항목
+// 17-2. 설비고장 수리내역 등록 수리작업자 정보
 @Getter
 @Setter
 @JsonInclude(NON_NULL)
-@Schema(description = "수리항목")
-public class RepairItemResponse {
+@Schema(description = "수리작업자")
+public class RepairWorkerResponse {
     @Schema(description = "고유아이디")
     Long id;
 
-    @Schema(description = "수리코드")
-    RepairCodeResponse repairCode;
+    @Schema(description = "작업자")
+    UserResponse.idAndCodeAndName user;
 }

--- a/src/main/java/com/mes/mesBackend/dto/response/UserResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/UserResponse.java
@@ -59,4 +59,16 @@ public class UserResponse {
         @Schema(description = "이름")
         String korName;    // 이름
     }
+
+    @Getter
+    @Setter
+    @Schema(description = "직원")
+    public static class idAndCodeAndName {
+        @Schema(description = "고유아이디")
+        Long id;
+        @Schema(description = "사번")
+        String userCode;     // 사번
+        @Schema(description = "이름")
+        String korName;    // 이름
+    }
 }

--- a/src/main/java/com/mes/mesBackend/entity/Equipment.java
+++ b/src/main/java/com/mes/mesBackend/entity/Equipment.java
@@ -46,9 +46,6 @@ public class Equipment extends BaseTimeEntity {
     @Column(name = "EQUIPMENT_NAME", nullable = false, columnDefinition = "varchar(255) COMMENT '설비명'")
     private String equipmentName;        // 설비명
 
-    @Column(name = "EQUIPMENT_TYPE", columnDefinition = "varchar(255) COMMENT '설비유형'")
-    private String equipmentType;        // 설비유형
-
     @Column(name = "MODEL", columnDefinition = "varchar(255) COMMENT '규격모델'", nullable = false)
     private String model;               // 규격&모델
 
@@ -73,8 +70,8 @@ public class Equipment extends BaseTimeEntity {
 
     // 다대일 단방향
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "WORK_LINE", columnDefinition = "bigint COMMENT '작업라인'", nullable = false)
-    private WorkLine workLine;              // 작업라인
+    @JoinColumn(name = "WORK_LINE", columnDefinition = "bigint COMMENT '작업라인,설비유형'", nullable = false)
+    private WorkLine workLine;              // 작업라인,설비유형
 
     @Column(name = "CHECK_CYCLE", columnDefinition = "int COMMENT '점검주기'", nullable = false)
     private int checkCycle;             // 점검주기
@@ -93,7 +90,6 @@ public class Equipment extends BaseTimeEntity {
     public void update(Equipment newEquipment, Client newClient, WorkLine newWorkLine) {
         setEquipmentCode(newEquipment.equipmentCode);
         setEquipmentName(newEquipment.equipmentName);
-        setEquipmentType(newEquipment.equipmentType);
         setModel(newEquipment.model);
         setClient(newClient);
         setPurchaseDate(newEquipment.purchaseDate);

--- a/src/main/java/com/mes/mesBackend/entity/RepairCode.java
+++ b/src/main/java/com/mes/mesBackend/entity/RepairCode.java
@@ -1,0 +1,42 @@
+package com.mes.mesBackend.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PUBLIC;
+
+// 수리코드
+@AllArgsConstructor
+@NoArgsConstructor(access = PUBLIC)
+@Entity(name = "REPAIR_CODES")
+@Data
+public class RepairCode extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "ID", columnDefinition = "bigint COMMENT '수리코드 고유아이디'")
+    private Long id;
+
+    @Column(name = "REPAIR_CODE", columnDefinition = "varchar(255) COMMENT '수리코드'", nullable = false)
+    private String repairCode;
+
+    @Column(name = "REPAIR_CONTENT", columnDefinition = "varchar(500) COMMENT '수리내용'", nullable = false)
+    private String repairContent;
+
+    @Column(name = "DELETE_YN", columnDefinition = "bit(1) COMMENT '삭제여부'", nullable = false)
+    private boolean deleteYn = false;
+
+    public void delete() {
+        setDeleteYn(true);
+    }
+
+    public void update(RepairCode newRepairCode) {
+        setRepairCode(newRepairCode.getRepairCode());
+        setRepairContent(newRepairCode.getRepairContent());
+    }
+}

--- a/src/main/java/com/mes/mesBackend/entity/RepairWorker.java
+++ b/src/main/java/com/mes/mesBackend/entity/RepairWorker.java
@@ -10,14 +10,15 @@ import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PUBLIC;
 
-// 17-2. 설비 고장 수리 내역 수리항목
+// 17-2. 설비 고장 수리 내역 수리작업자
 @AllArgsConstructor
 @NoArgsConstructor(access = PUBLIC)
-@Entity(name = "REPAIR_ITEMS")
+@Entity(name = "REPAIR_WORKERS")
 @Data
-public class RepairItem extends BaseTimeEntity {
-    @Id @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "ID", columnDefinition = "bigint COMMENT '수리항목 고유아이디'")
+public class RepairWorker extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "ID", columnDefinition = "bigint COMMENT '수리작업자 고유아이디'")
     private Long id;
 
     @ManyToOne(fetch = LAZY)
@@ -25,22 +26,22 @@ public class RepairItem extends BaseTimeEntity {
     private EquipmentBreakdown equipmentBreakdown;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "REPAIR_CODE", columnDefinition = "bigint COMMENT '수리코드'", nullable = false)
-    private RepairCode repairCode;
+    @JoinColumn(name = "USER", columnDefinition = "bigint COMMENT '작업자'", nullable = false)
+    private User user;
 
     @Column(name = "DELETE_YN", columnDefinition = "bit(1) COMMENT '삭제여부'", nullable = false)
     private boolean deleteYn = false;
 
-    public void add(EquipmentBreakdown equipmentBreakdown, RepairCode repairCode) {
+    public void add(EquipmentBreakdown equipmentBreakdown, User user) {
         setEquipmentBreakdown(equipmentBreakdown);
-        setRepairCode(repairCode);
+        setUser(user);
     }
 
     public void delete() {
         setDeleteYn(true);
     }
 
-    public void update(RepairCode newRepairCode) {
-        setRepairCode(newRepairCode);
+    public void update(User newUser) {
+        setUser(newUser);
     }
 }

--- a/src/main/java/com/mes/mesBackend/repository/RepairCodeRepository.java
+++ b/src/main/java/com/mes/mesBackend/repository/RepairCodeRepository.java
@@ -1,0 +1,10 @@
+package com.mes.mesBackend.repository;
+
+import com.mes.mesBackend.entity.RepairCode;
+import com.mes.mesBackend.repository.custom.JpaCustomRepository;
+import org.springframework.stereotype.Repository;
+
+// 수리코드
+@Repository
+public interface RepairCodeRepository extends JpaCustomRepository<RepairCode, Long> {
+}

--- a/src/main/java/com/mes/mesBackend/repository/RepairWorkerRepository.java
+++ b/src/main/java/com/mes/mesBackend/repository/RepairWorkerRepository.java
@@ -1,0 +1,16 @@
+package com.mes.mesBackend.repository;
+
+import com.mes.mesBackend.entity.EquipmentBreakdown;
+import com.mes.mesBackend.entity.RepairWorker;
+import com.mes.mesBackend.repository.custom.JpaCustomRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+// 17-2. 수리작업자 정보
+@Repository
+public interface RepairWorkerRepository extends JpaCustomRepository<RepairWorker, Long> {
+    List<RepairWorker> findAllByEquipmentBreakdownAndDeleteYnFalse(EquipmentBreakdown equipmentBreakdown);
+    Optional<RepairWorker> findByIdAndEquipmentBreakdownAndDeleteYnFalse(Long id, EquipmentBreakdown equipmentBreakdown);
+}

--- a/src/main/java/com/mes/mesBackend/repository/custom/EquipmentBreakdownRepositoryCustom.java
+++ b/src/main/java/com/mes/mesBackend/repository/custom/EquipmentBreakdownRepositoryCustom.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 // 17-2. 설비 고장 수리내역 등록
 public interface EquipmentBreakdownRepositoryCustom {
     // 설비고장 리스트 검색 조회, 검색조건: 작업장 id, 설비유형, 작업기간 fromDate~toDate
-    List<EquipmentBreakdownResponse> findEquipmentBreakdownResponsesByCondition(Long workCenterId, String equipmentType, LocalDate fromDate, LocalDate toDate);
+    List<EquipmentBreakdownResponse> findEquipmentBreakdownResponsesByCondition(Long workCenterId, Long workLineId, LocalDate fromDate, LocalDate toDate);
     // 설비고장 단일조회
     Optional<EquipmentBreakdownResponse> findEquipmentBreakdownResponseById(Long equipmentBreakdownId);
     // 설비고장 id 로 수리전 파일들 조회

--- a/src/main/java/com/mes/mesBackend/repository/custom/EquipmentCheckDetailRepositoryCustom.java
+++ b/src/main/java/com/mes/mesBackend/repository/custom/EquipmentCheckDetailRepositoryCustom.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface EquipmentCheckDetailRepositoryCustom {
     // 설비 리스트 조회
     // 검색조건: 설비유형, 점검유형(보류), 작업기간(디테일 정보 생성날짜 기준) fromDate~toDate
-    List<EquipmentCheckResponse> findEquipmentChecksResponseByCondition(String equipmentType, LocalDate fromDate, LocalDate toDate);
+    List<EquipmentCheckResponse> findEquipmentChecksResponseByCondition(Long workLineId, LocalDate fromDate, LocalDate toDate);
     // 설비 단일 조회
     Optional<EquipmentCheckResponse> findEquipmentChecksResponseByEquipmentId(Long equipmentId);
     // ================================================ 설비점검 실적 상세 정보 ================================================

--- a/src/main/java/com/mes/mesBackend/repository/impl/EquipmentCheckDetailRepositoryImpl.java
+++ b/src/main/java/com/mes/mesBackend/repository/impl/EquipmentCheckDetailRepositoryImpl.java
@@ -31,7 +31,7 @@ public class EquipmentCheckDetailRepositoryImpl implements EquipmentCheckDetailR
     // 검색조건: 설비유형, 점검유형(보류), 작업기간(디테일 정보 생성날짜 기준) fromDate~toDate
     @Override
     public List<EquipmentCheckResponse> findEquipmentChecksResponseByCondition(
-            String equipmentType,
+            Long workLineId,
             LocalDate fromDate,
             LocalDate toDate
     ) {
@@ -54,7 +54,7 @@ public class EquipmentCheckDetailRepositoryImpl implements EquipmentCheckDetailR
                 .leftJoin(workCenter).on(workCenter.id.eq(workLine.workCenter.id))
                 .leftJoin(equipmentCheckDetail).on(equipmentCheckDetail.equipment.id.eq(equipment.id))
                 .where(
-                        isEquipmentTypeContain(equipmentType),
+                        isEquipmentTypeContain(workLineId),
                         isWorkDateBetween(fromDate, toDate),
                         isEquipmentDeleteYnFalse()
                 )
@@ -153,9 +153,9 @@ public class EquipmentCheckDetailRepositoryImpl implements EquipmentCheckDetailR
     }
 
     // 검색조건:
-    // 설비유형
-    private BooleanExpression isEquipmentTypeContain(String equipmentType) {
-        return equipmentType != null ? equipment.equipmentType.contains(equipmentType) : null;
+    // 설비유형(작업라인 id)
+    private BooleanExpression isEquipmentTypeContain(Long workLineId) {
+        return workLineId != null ? equipment.workLine.id.eq(workLineId) : null;
     }
     // 작업기간(디테일 정보 생성날짜 기준) fromDate~toDate
     private BooleanExpression isWorkDateBetween(LocalDate fromDate, LocalDate toDate) {

--- a/src/main/java/com/mes/mesBackend/service/EquipmentBreakdownService.java
+++ b/src/main/java/com/mes/mesBackend/service/EquipmentBreakdownService.java
@@ -1,11 +1,8 @@
 package com.mes.mesBackend.service;
 
 import com.mes.mesBackend.dto.request.EquipmentBreakdownRequest;
-import com.mes.mesBackend.dto.request.RepairItemRequest;
 import com.mes.mesBackend.dto.request.RepairPartRequest;
-import com.mes.mesBackend.dto.response.EquipmentBreakdownResponse;
-import com.mes.mesBackend.dto.response.RepairItemResponse;
-import com.mes.mesBackend.dto.response.RepairPartResponse;
+import com.mes.mesBackend.dto.response.*;
 import com.mes.mesBackend.exception.BadRequestException;
 import com.mes.mesBackend.exception.NotFoundException;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,7 +16,7 @@ public interface EquipmentBreakdownService {
     // 설비고장 생성
     EquipmentBreakdownResponse createEquipmentBreakdown(EquipmentBreakdownRequest equipmentBreakdownRequest) throws NotFoundException;
     // 설비고장 리스트 검색 조회, 검색조건: 작업장 id, 설비유형, 작업기간 fromDate~toDate
-    List<EquipmentBreakdownResponse> getEquipmentBreakdowns(Long workCenterId, String equipmentType, LocalDate fromDate, LocalDate toDate);
+    List<EquipmentBreakdownResponse> getEquipmentBreakdowns(Long workCenterId, Long workLineId, LocalDate fromDate, LocalDate toDate);
     // 설비고장 단일조회
     EquipmentBreakdownResponse getEquipmentBreakdown(Long equipmentBreakdownId) throws NotFoundException;
     // 설비고장 수정
@@ -32,13 +29,13 @@ public interface EquipmentBreakdownService {
     void deleteFileToEquipmentBreakdown(Long equipmentBreakdownId, Long fileId) throws NotFoundException;
     // ============================================== 수리항목 ==============================================
     // 수리항목 생성
-    RepairItemResponse createRepairItem(Long equipmentBreakdownId, RepairItemRequest repairItemRequest) throws NotFoundException;
+    RepairItemResponse createRepairItem(Long equipmentBreakdownId, Long repairCodeId) throws NotFoundException;
     // 수리항목 전체 조회
     List<RepairItemResponse> getRepairItemResponses(Long equipmentBreakdownId) throws NotFoundException;
     // 수리항목 단일 조회
     RepairItemResponse getRepairItemResponse(Long equipmentBreakdownId, Long repairItemId) throws NotFoundException;
     // 수리항목 수정
-    RepairItemResponse updateRepairItem(Long equipmentBreakdownId, Long repairItemId, RepairItemRequest repairItemRequest) throws NotFoundException;
+    RepairItemResponse updateRepairItem(Long equipmentBreakdownId, Long repairItemId, Long repairCodeId) throws NotFoundException;
     // 수리항목 삭제
     void deleteRepairItem(Long equipmentBreakdownId, Long repairItemId) throws NotFoundException;
     // ============================================== 수리부품정보 ==============================================
@@ -52,4 +49,18 @@ public interface EquipmentBreakdownService {
     RepairPartResponse updateRepairPart(Long equipmentBreakdownId, Long repairItemId, Long repairPartId, RepairPartRequest repairPartRequest) throws NotFoundException;
     // 수리부품 삭제
     void deleteRepairPart(Long equipmentBreakdownId, Long repairItemId, Long repairPartId) throws NotFoundException;
+
+    List<EquipmentRepairHistoryResponse> getEquipmentRepairHistories(Long workCenterId, String equipmentType, String repairItem, LocalDate fromDate, LocalDate toDate);
+
+    // ============================================== 수리작업자 정보 ==============================================
+    // 수리작업자 생성
+    RepairWorkerResponse createRepairWorker(Long equipmentBreakdownId, Long userId) throws NotFoundException;
+    // 수리작업자 전체 조회
+    List<RepairWorkerResponse> getRepairWorkerResponses(Long equipmentBreakdownId) throws NotFoundException;
+    // 수리작업자 단일 조회
+    RepairWorkerResponse getRepairWorkerResponse(Long equipmentBreakdownId, Long repairWorkerId) throws NotFoundException;
+    // 수리작업자 수정
+    RepairWorkerResponse updateRepairWorker(Long equipmentBreakdownId, Long repairWorkerId, Long userId) throws NotFoundException;
+    // 수리작업자 삭제
+    void deleteRepairWorker(Long equipmentBreakdownId, Long repairWorkerId) throws NotFoundException;
 }

--- a/src/main/java/com/mes/mesBackend/service/EquipmentCheckService.java
+++ b/src/main/java/com/mes/mesBackend/service/EquipmentCheckService.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface EquipmentCheckService {
     // 설비 리스트 조회
     // 검색조건: 설비유형, 점검유형(보류), 작업기간(디테일 정보 생성날짜 기준) fromDate~toDate
-    List<EquipmentCheckResponse> getEquipmentChecks(String equipmentType, LocalDate fromDate, LocalDate toDate);
+    List<EquipmentCheckResponse> getEquipmentChecks(Long workLineId, LocalDate fromDate, LocalDate toDate);
     // 설비 단일 조회
     EquipmentCheckResponse getEquipmentCheckResponse(Long equipmentId) throws NotFoundException;
 

--- a/src/main/java/com/mes/mesBackend/service/RepairCodeService.java
+++ b/src/main/java/com/mes/mesBackend/service/RepairCodeService.java
@@ -1,0 +1,23 @@
+package com.mes.mesBackend.service;
+
+import com.mes.mesBackend.dto.request.RepairCodeRequest;
+import com.mes.mesBackend.dto.response.RepairCodeResponse;
+import com.mes.mesBackend.entity.RepairCode;
+import com.mes.mesBackend.exception.NotFoundException;
+
+import java.util.List;
+
+public interface RepairCodeService {
+    // 수리코드 생성
+    RepairCodeResponse createRepairCode(RepairCodeRequest repairCodeRequest);
+    // 수리코드 단일 조회
+    RepairCodeResponse getRepairCode(Long id) throws NotFoundException;
+    // 수리코드 전체 조회
+    List<RepairCodeResponse> getRepairCodes();
+    // 수리코드 수정
+    RepairCodeResponse updateRepairCode(Long id, RepairCodeRequest repairCodeRequest) throws NotFoundException;
+    // 수리코드 삭제
+    void deleteRepairCode(Long id) throws NotFoundException;
+    // 수리코드 단일 조회 및 예외
+    RepairCode getRepairCodeOrThrow(Long id) throws NotFoundException;
+}

--- a/src/main/java/com/mes/mesBackend/service/impl/EquipmentCheckServiceImpl.java
+++ b/src/main/java/com/mes/mesBackend/service/impl/EquipmentCheckServiceImpl.java
@@ -30,9 +30,9 @@ public class EquipmentCheckServiceImpl implements EquipmentCheckService {
     // 설비 리스트 조회
     // 검색조건: 설비유형, 점검유형(보류), 작업기간(디테일 정보 생성날짜 기준) fromDate~toDate
     @Override
-    public List<EquipmentCheckResponse> getEquipmentChecks(String equipmentType, LocalDate fromDate, LocalDate toDate) {
+    public List<EquipmentCheckResponse> getEquipmentChecks(Long workLineId, LocalDate fromDate, LocalDate toDate) {
         // TODO(점검유형 보류)
-        return equipmentCheckDetailRepo.findEquipmentChecksResponseByCondition(equipmentType, fromDate, toDate);
+        return equipmentCheckDetailRepo.findEquipmentChecksResponseByCondition(workLineId, fromDate, toDate);
     }
 
     // 설비 단일 조회

--- a/src/main/java/com/mes/mesBackend/service/impl/RepairCodeServiceImpl.java
+++ b/src/main/java/com/mes/mesBackend/service/impl/RepairCodeServiceImpl.java
@@ -1,0 +1,68 @@
+package com.mes.mesBackend.service.impl;
+
+import com.mes.mesBackend.dto.request.RepairCodeRequest;
+import com.mes.mesBackend.dto.response.RepairCodeResponse;
+import com.mes.mesBackend.entity.RepairCode;
+import com.mes.mesBackend.exception.NotFoundException;
+import com.mes.mesBackend.mapper.ModelMapper;
+import com.mes.mesBackend.repository.RepairCodeRepository;
+import com.mes.mesBackend.service.RepairCodeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+// 수리코드
+@Service
+@RequiredArgsConstructor
+public class RepairCodeServiceImpl implements RepairCodeService {
+    private final RepairCodeRepository repairCodeRepository;
+    private final ModelMapper mapper;
+
+    // 수리코드 생성
+    @Override
+    public RepairCodeResponse createRepairCode(RepairCodeRequest repairCodeRequest) {
+        RepairCode repairCode = mapper.toEntity(repairCodeRequest, RepairCode.class);
+        repairCodeRepository.save(repairCode);
+        return mapper.toResponse(repairCode, RepairCodeResponse.class);
+    }
+
+    // 수리코드 단일 조회
+    @Override
+    public RepairCodeResponse getRepairCode(Long id) throws NotFoundException {
+        RepairCode repairCode = getRepairCodeOrThrow(id);
+        return mapper.toResponse(repairCode, RepairCodeResponse.class);
+    }
+
+    // 수리코드 리스트 조회
+    @Override
+    public List<RepairCodeResponse> getRepairCodes() {
+        List<RepairCode> repairCodes = repairCodeRepository.findAllByDeleteYnFalse();
+        return mapper.toListResponses(repairCodes, RepairCodeResponse.class);
+    }
+
+    // 수리코드 수정
+    @Override
+    public RepairCodeResponse updateRepairCode(Long id, RepairCodeRequest repairCodeRequest) throws NotFoundException {
+        RepairCode findRepairCode = getRepairCodeOrThrow(id);
+        RepairCode newRepairCode = mapper.toEntity(repairCodeRequest, RepairCode.class);
+        findRepairCode.update(newRepairCode);
+        repairCodeRepository.save(findRepairCode);
+        return mapper.toResponse(findRepairCode, RepairCodeResponse.class);
+    }
+
+    // 수리코드 삭제
+    @Override
+    public void deleteRepairCode(Long id) throws NotFoundException {
+        RepairCode repairCode = getRepairCodeOrThrow(id);
+        repairCode.delete();
+        repairCodeRepository.save(repairCode);
+    }
+
+    // 수리코드 조회 및 예외
+    @Override
+    public RepairCode getRepairCodeOrThrow(Long id) throws NotFoundException {
+        return repairCodeRepository.findByIdAndDeleteYnFalse(id)
+                .orElseThrow(() -> new NotFoundException("repairCode does not exist. input id: " + id));
+    }
+}


### PR DESCRIPTION
- 수리코드 api 구현

17-2. 설비 고장 수리내역 등록
- 수리항목 api 변경
    - 수리항목 응답 데이터 형태 변경되었습니다.
    - 수리항목 생성, 수정 데이터 변경되었습니다.
- 검색조건
    - 설비유형이 String 에서 작업라인 id 로 변경되었습니다. 검색명은 같음

17-2. 설비 고장 수리내역 수리작업자 api 구현

17-1. 설비점검 실적 등록
- 검색조건 
    - 설비유형이 String 에서 작업라인 id 로 변경되었습니다. 검색명은 같습니다.