### PR TITLE
16. 제품검사 api 구현

### DIFF
--- a/src/main/java/com/mes/mesBackend/controller/LotMasterController.java
+++ b/src/main/java/com/mes/mesBackend/controller/LotMasterController.java
@@ -34,7 +34,7 @@ public class LotMasterController {
 
 
     // LOT 마스터 조회
-    // 검색조건: 품목그룹 id, LOT 번호, 품번|품명, 창고 id, 등록유형, 재고유무, LOT 유형, 검사중여부
+    // 검색조건: 품목그룹 id, LOT 번호, 품번|품명, 창고 id, 등록유형, 재고유무, LOT 유형, 검사중여부, 품목계정
     @GetMapping
     @ResponseBody
     @Operation(

--- a/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestEnrollmentController.java
+++ b/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestEnrollmentController.java
@@ -3,6 +3,8 @@ package com.mes.mesBackend.controller;
 import com.mes.mesBackend.dto.request.InputTestDetailRequest;
 import com.mes.mesBackend.dto.response.InputTestDetailResponse;
 import com.mes.mesBackend.dto.response.InputTestRequestInfoResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
+import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.exception.BadRequestException;
 import com.mes.mesBackend.exception.NotFoundException;
 import com.mes.mesBackend.logger.CustomLogger;
@@ -30,6 +32,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.OUT_SOURCING;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
@@ -63,9 +66,11 @@ public class OutsourcingInputTestEnrollmentController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "요청기간 fromDate") LocalDate fromDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "요청기간 toDate") LocalDate toDate,
             @RequestParam(required = false) @Parameter(description = "제조사 id(clientId)") Long manufactureId,
+            @RequestParam(required = false) @Parameter(description = "검사유형(삭제)", hidden = true) TestType testType,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
-    ) {
-        List<InputTestRequestInfoResponse> inputTestInfos = inputTestDetailService.getInputTestRequestInfo(warehouseId, itemNoAndName, completionYn, purchaseInputNo, itemGroupId, lotTypeId, fromDate, toDate, manufactureId, false);
+    ) throws NotFoundException {
+        List<InputTestRequestInfoResponse> inputTestInfos = inputTestDetailService.getInputTestRequestInfo(
+                warehouseId, itemNoAndName, completionYn, purchaseInputNo, itemGroupId, lotTypeId, fromDate, toDate, manufactureId, OUT_SOURCING, testType);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getOutsourcingInputTestRequestInfo.");
         return new ResponseEntity<>(inputTestInfos, HttpStatus.OK);
@@ -86,7 +91,7 @@ public class OutsourcingInputTestEnrollmentController {
             @RequestBody @Valid InputTestDetailRequest inputTestDetailRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createInputTestDetail(inputTestRequestId, inputTestDetailRequest, false);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.createInputTestDetail(inputTestRequestId, inputTestDetailRequest, OUT_SOURCING);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createOutsourcingInputTestEnrollment.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -100,7 +105,7 @@ public class OutsourcingInputTestEnrollmentController {
             @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        List<InputTestDetailResponse> inputTestDetails = inputTestDetailService.getInputTestDetails(inputTestRequestId, false);
+        List<InputTestDetailResponse> inputTestDetails = inputTestDetailService.getInputTestDetails(inputTestRequestId, OUT_SOURCING);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getOutsourcingInputTestEnrollments.");
         return new ResponseEntity<>(inputTestDetails, HttpStatus.OK);
@@ -123,7 +128,9 @@ public class OutsourcingInputTestEnrollmentController {
             @RequestBody @Valid InputTestDetailRequest inputTestDetailRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.updateInputTestDetail(inputTestRequestId, inputTestDetailId, inputTestDetailRequest, false);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.updateInputTestDetail(
+                inputTestRequestId, inputTestDetailId, inputTestDetailRequest, OUT_SOURCING
+        );
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is modified the " + inputTestDetail.getId() + " from updateOutsourcingInputTestEnrollment.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -144,7 +151,7 @@ public class OutsourcingInputTestEnrollmentController {
             @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        inputTestDetailService.deleteInputTestDetail(inputTestRequestId, inputTestDetailId, false);
+        inputTestDetailService.deleteInputTestDetail(inputTestRequestId, inputTestDetailId, OUT_SOURCING);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + inputTestDetailId + " from deleteOutsourcingInputTestEnrollment.");
         return new ResponseEntity(NO_CONTENT);
@@ -167,7 +174,7 @@ public class OutsourcingInputTestEnrollmentController {
             @RequestPart(required = false) @Parameter(description = "검사성적서 파일") MultipartFile testReportFile,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, IOException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createTestReportFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportFile, false);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.createTestReportFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportFile, OUT_SOURCING);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createTestReportFileToOutsourcingInputTestEnrollment.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -190,7 +197,7 @@ public class OutsourcingInputTestEnrollmentController {
             @RequestPart(required = false) @Parameter(description = "COC 파일") MultipartFile cocFile,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, IOException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, cocFile, false);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.createCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, cocFile, OUT_SOURCING);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createCocFileToOutsourcingInputTestEnrollment.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -213,7 +220,7 @@ public class OutsourcingInputTestEnrollmentController {
             @RequestParam(required = false) @Parameter(description = "coc 파일") boolean cocDeleteYn,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        inputTestDetailService.deleteTestReportFileAndCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportDeleteYn, cocDeleteYn, false);
+        inputTestDetailService.deleteTestReportFileAndCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportDeleteYn, cocDeleteYn, OUT_SOURCING);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + inputTestDetailId + " from deleteTestReportFileToOutsourcingInputTestEnrollment.");
         return new ResponseEntity(NO_CONTENT);

--- a/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestEnrollmentController.java
+++ b/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestEnrollmentController.java
@@ -157,72 +157,72 @@ public class OutsourcingInputTestEnrollmentController {
         return new ResponseEntity(NO_CONTENT);
     }
 
-    // 검사성적서 파일
-    @PutMapping(value = "/{input-test-request-id}/input-test-details/{input-test-detail-id}/test-report-files", consumes = MULTIPART_FORM_DATA_VALUE)
-    @ResponseBody
-    @Operation(summary = "검사성적서 파일 추가")
-    @ApiResponses(
-            value = {
-                    @ApiResponse(responseCode = "200", description = "success"),
-                    @ApiResponse(responseCode = "404", description = "not found resource"),
-                    @ApiResponse(responseCode = "400", description = "bad request")
-            }
-    )
-    public ResponseEntity<InputTestDetailResponse> createTestReportFileToOutsourcingInputTestEnrollment(
-            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
-            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
-            @RequestPart(required = false) @Parameter(description = "검사성적서 파일") MultipartFile testReportFile,
-            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
-    ) throws NotFoundException, IOException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createTestReportFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportFile, OUT_SOURCING);
-        cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createTestReportFileToOutsourcingInputTestEnrollment.");
-        return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
-    }
-
-    // COC 파일 추가
-    @PutMapping(value = "/{input-test-request-id}/input-test-details/{input-test-detail-id}/coc-files", consumes = MULTIPART_FORM_DATA_VALUE)
-    @ResponseBody
-    @Operation(summary = "COC 파일 추가")
-    @ApiResponses(
-            value = {
-                    @ApiResponse(responseCode = "200", description = "success"),
-                    @ApiResponse(responseCode = "404", description = "not found resource"),
-                    @ApiResponse(responseCode = "400", description = "bad request")
-            }
-    )
-    public ResponseEntity<InputTestDetailResponse> createCocFileToOutsourcingInputTestEnrollment(
-            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
-            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
-            @RequestPart(required = false) @Parameter(description = "COC 파일") MultipartFile cocFile,
-            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
-    ) throws NotFoundException, IOException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, cocFile, OUT_SOURCING);
-        cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createCocFileToOutsourcingInputTestEnrollment.");
-        return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
-    }
-
-    // 파일 삭제
-    @DeleteMapping("/{input-test-request-id}/input-test-details/{input-test-detail-id}/files")
-    @ResponseBody()
-    @Operation(summary = "검사정보 파일 삭제", description = "")
-    @ApiResponses(
-            value = {
-                    @ApiResponse(responseCode = "204", description = "no content"),
-                    @ApiResponse(responseCode = "404", description = "not found resource")
-            }
-    )
-    public ResponseEntity<Void> deleteTestReportFileToOutsourcingInputTestEnrollment(
-            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
-            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
-            @RequestParam(required = false) @Parameter(description = "검사성적서 파일") boolean testReportDeleteYn,
-            @RequestParam(required = false) @Parameter(description = "coc 파일") boolean cocDeleteYn,
-            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
-    ) throws NotFoundException {
-        inputTestDetailService.deleteTestReportFileAndCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportDeleteYn, cocDeleteYn, OUT_SOURCING);
-        cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + inputTestDetailId + " from deleteTestReportFileToOutsourcingInputTestEnrollment.");
-        return new ResponseEntity(NO_CONTENT);
-    }
+//    // 검사성적서 파일
+//    @PutMapping(value = "/{input-test-request-id}/input-test-details/{input-test-detail-id}/test-report-files", consumes = MULTIPART_FORM_DATA_VALUE)
+//    @ResponseBody
+//    @Operation(summary = "검사성적서 파일 추가")
+//    @ApiResponses(
+//            value = {
+//                    @ApiResponse(responseCode = "200", description = "success"),
+//                    @ApiResponse(responseCode = "404", description = "not found resource"),
+//                    @ApiResponse(responseCode = "400", description = "bad request")
+//            }
+//    )
+//    public ResponseEntity<InputTestDetailResponse> createTestReportFileToOutsourcingInputTestEnrollment(
+//            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+//            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
+//            @RequestPart(required = false) @Parameter(description = "검사성적서 파일") MultipartFile testReportFile,
+//            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+//    ) throws NotFoundException, IOException, BadRequestException {
+//        InputTestDetailResponse inputTestDetail = inputTestDetailService.createTestReportFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportFile, OUT_SOURCING);
+//        cLogger = new MongoLogger(logger, "mongoTemplate");
+//        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createTestReportFileToOutsourcingInputTestEnrollment.");
+//        return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
+//    }
+//
+//    // COC 파일 추가
+//    @PutMapping(value = "/{input-test-request-id}/input-test-details/{input-test-detail-id}/coc-files", consumes = MULTIPART_FORM_DATA_VALUE)
+//    @ResponseBody
+//    @Operation(summary = "COC 파일 추가")
+//    @ApiResponses(
+//            value = {
+//                    @ApiResponse(responseCode = "200", description = "success"),
+//                    @ApiResponse(responseCode = "404", description = "not found resource"),
+//                    @ApiResponse(responseCode = "400", description = "bad request")
+//            }
+//    )
+//    public ResponseEntity<InputTestDetailResponse> createCocFileToOutsourcingInputTestEnrollment(
+//            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+//            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
+//            @RequestPart(required = false) @Parameter(description = "COC 파일") MultipartFile cocFile,
+//            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+//    ) throws NotFoundException, IOException, BadRequestException {
+//        InputTestDetailResponse inputTestDetail = inputTestDetailService.createCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, cocFile, OUT_SOURCING);
+//        cLogger = new MongoLogger(logger, "mongoTemplate");
+//        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createCocFileToOutsourcingInputTestEnrollment.");
+//        return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
+//    }
+//
+//    // 파일 삭제
+//    @DeleteMapping("/{input-test-request-id}/input-test-details/{input-test-detail-id}/files")
+//    @ResponseBody()
+//    @Operation(summary = "검사정보 파일 삭제", description = "")
+//    @ApiResponses(
+//            value = {
+//                    @ApiResponse(responseCode = "204", description = "no content"),
+//                    @ApiResponse(responseCode = "404", description = "not found resource")
+//            }
+//    )
+//    public ResponseEntity<Void> deleteTestReportFileToOutsourcingInputTestEnrollment(
+//            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+//            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
+//            @RequestParam(required = false) @Parameter(description = "검사성적서 파일") boolean testReportDeleteYn,
+//            @RequestParam(required = false) @Parameter(description = "coc 파일") boolean cocDeleteYn,
+//            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+//    ) throws NotFoundException {
+//        inputTestDetailService.deleteTestReportFileAndCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportDeleteYn, cocDeleteYn, OUT_SOURCING);
+//        cLogger = new MongoLogger(logger, "mongoTemplate");
+//        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + inputTestDetailId + " from deleteTestReportFileToOutsourcingInputTestEnrollment.");
+//        return new ResponseEntity(NO_CONTENT);
+//    }
 }

--- a/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestPerformanceController.java
+++ b/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestPerformanceController.java
@@ -1,6 +1,8 @@
 package com.mes.mesBackend.controller;
 
 import com.mes.mesBackend.dto.response.InputTestPerformanceResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
+import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.logger.CustomLogger;
 import com.mes.mesBackend.logger.LogService;
 import com.mes.mesBackend.logger.MongoLogger;
@@ -20,6 +22,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
+
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.OUT_SOURCING;
 
 // 15-3. 검사실적 조회
 @RequestMapping(value = "/outsourcing-input-test-performances")
@@ -46,10 +50,12 @@ public class OutsourcingInputTestPerformanceController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "검사기간 toDate") LocalDate toDate,
             @RequestParam(required = false) @Parameter(description = "품명|품번") String itemNoAndName,
             @RequestParam(required = false) @Parameter(description = "거래처 id") Long clientId,
-            @RequestParam(required = false) @Parameter(description = "입고번호 (purchaseInputId)") Long purchaseInputNo,
+            @RequestParam(required = false) @Parameter(description = "입고번호 (outsourcingInputId)") Long inputId,
+            @RequestParam(required = false) @Parameter(description = "검사유형", hidden = true) TestType testType,
+            @RequestParam(required = false) @Parameter(description = "검사창고", hidden = true) Long wareHouseId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) {
-        List<InputTestPerformanceResponse> inputTestPerformanceResponses = inputTestPerformanceService.getInputTestPerformances(fromDate, toDate, itemNoAndName, clientId, purchaseInputNo, false);
+        List<InputTestPerformanceResponse> inputTestPerformanceResponses = inputTestPerformanceService.getInputTestPerformances(fromDate, toDate, itemNoAndName, clientId, inputId, OUT_SOURCING, testType, wareHouseId);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getOutsourcingInputTestPerformances.");
         return new ResponseEntity<>(inputTestPerformanceResponses, HttpStatus.OK);

--- a/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestScheduleController.java
+++ b/src/main/java/com/mes/mesBackend/controller/OutsourcingInputTestScheduleController.java
@@ -1,6 +1,7 @@
 package com.mes.mesBackend.controller;
 
 import com.mes.mesBackend.dto.response.InputTestScheduleResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.logger.CustomLogger;
 import com.mes.mesBackend.logger.LogService;
@@ -21,6 +22,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
+
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.OUT_SOURCING;
 
 // 15-4. 검사대기 현황
 @RequestMapping(value = "/outsourcing-input-test-schedules")
@@ -51,7 +54,9 @@ public class OutsourcingInputTestScheduleController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "검사요청기간 toDate") LocalDate toDate,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) {
-        List<InputTestScheduleResponse> inputTestScheduleResponses = inputTestPerformanceService.getInputTestSchedules(wareHouseId, testType, itemNoAndName, clientId, fromDate, toDate, false);
+        List<InputTestScheduleResponse> inputTestScheduleResponses = inputTestPerformanceService.getInputTestSchedules(
+                wareHouseId, testType, itemNoAndName, clientId, fromDate, toDate, OUT_SOURCING
+        );
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getOutsourcingInputTestSchedules.");
         return new ResponseEntity<>(inputTestScheduleResponses, HttpStatus.OK);

--- a/src/main/java/com/mes/mesBackend/controller/PartInputTestEnrollmentController.java
+++ b/src/main/java/com/mes/mesBackend/controller/PartInputTestEnrollmentController.java
@@ -3,6 +3,8 @@ package com.mes.mesBackend.controller;
 import com.mes.mesBackend.dto.request.InputTestDetailRequest;
 import com.mes.mesBackend.dto.response.InputTestDetailResponse;
 import com.mes.mesBackend.dto.response.InputTestRequestInfoResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
+import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.exception.BadRequestException;
 import com.mes.mesBackend.exception.NotFoundException;
 import com.mes.mesBackend.logger.CustomLogger;
@@ -30,6 +32,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PART;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
@@ -63,9 +66,10 @@ public class PartInputTestEnrollmentController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "요청기간 fromDate") LocalDate fromDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "요청기간 toDate") LocalDate toDate,
             @RequestParam(required = false) @Parameter(description = "제조사 id(clientId)") Long manufactureId,
+            @RequestParam(required = false) @Parameter(description = "검사유형(삭제)", hidden = true) TestType testType,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
-    ) {
-        List<InputTestRequestInfoResponse> inputTestInfos = inputTestDetailService.getInputTestRequestInfo(warehouseId, itemNoAndName, completionYn, purchaseInputNo, itemGroupId, lotTypeId, fromDate, toDate, manufactureId, true);
+    ) throws NotFoundException {
+        List<InputTestRequestInfoResponse> inputTestInfos = inputTestDetailService.getInputTestRequestInfo(warehouseId, itemNoAndName, completionYn, purchaseInputNo, itemGroupId, lotTypeId, fromDate, toDate, manufactureId, PART, testType);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getItemInputTestRequestInfo.");
         return new ResponseEntity<>(inputTestInfos, HttpStatus.OK);
@@ -86,7 +90,7 @@ public class PartInputTestEnrollmentController {
             @RequestBody @Valid InputTestDetailRequest inputTestDetailRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createInputTestDetail(inputTestRequestId, inputTestDetailRequest, true);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.createInputTestDetail(inputTestRequestId, inputTestDetailRequest, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createItemInputTestDetail.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -107,7 +111,7 @@ public class PartInputTestEnrollmentController {
             @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.getInputTestDetail(inputTestRequestId, inputTestDetailId, true);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.getInputTestDetail(inputTestRequestId, inputTestDetailId, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the " + inputTestDetail.getId() + " from getItemInputTestDetail.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -121,7 +125,7 @@ public class PartInputTestEnrollmentController {
             @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        List<InputTestDetailResponse> inputTestDetails = inputTestDetailService.getInputTestDetails(inputTestRequestId, true);
+        List<InputTestDetailResponse> inputTestDetails = inputTestDetailService.getInputTestDetails(inputTestRequestId, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getItemInputTestDetails.");
         return new ResponseEntity<>(inputTestDetails, HttpStatus.OK);
@@ -144,7 +148,7 @@ public class PartInputTestEnrollmentController {
             @RequestBody @Valid InputTestDetailRequest inputTestDetailRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.updateInputTestDetail(inputTestRequestId, inputTestDetailId, inputTestDetailRequest, true);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.updateInputTestDetail(inputTestRequestId, inputTestDetailId, inputTestDetailRequest, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is modified the " + inputTestDetail.getId() + " from updateItemInputTestDetail.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -165,7 +169,7 @@ public class PartInputTestEnrollmentController {
             @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        inputTestDetailService.deleteInputTestDetail(inputTestRequestId, inputTestDetailId, true);
+        inputTestDetailService.deleteInputTestDetail(inputTestRequestId, inputTestDetailId, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + inputTestDetailId + " from deleteItemInputTestDetail.");
         return new ResponseEntity(NO_CONTENT);
@@ -188,7 +192,7 @@ public class PartInputTestEnrollmentController {
             @RequestPart(required = false) @Parameter(description = "검사성적서 파일") MultipartFile testReportFile,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, IOException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createTestReportFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportFile, true);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.createTestReportFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportFile, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createTestReportFileToItemInputTestDetail.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -211,7 +215,7 @@ public class PartInputTestEnrollmentController {
             @RequestPart(required = false) @Parameter(description = "COC 파일") MultipartFile cocFile,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, IOException, BadRequestException {
-        InputTestDetailResponse inputTestDetail = inputTestDetailService.createCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, cocFile, true);
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.createCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, cocFile, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createCocFileToItemInputTestDetail.");
         return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
@@ -234,7 +238,7 @@ public class PartInputTestEnrollmentController {
             @RequestParam(required = false) @Parameter(description = "coc 파일") boolean cocDeleteYn,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        inputTestDetailService.deleteTestReportFileAndCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportDeleteYn, cocDeleteYn, true);
+        inputTestDetailService.deleteTestReportFileAndCocFileToInputTestDetail(inputTestRequestId, inputTestDetailId, testReportDeleteYn, cocDeleteYn, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + inputTestDetailId + " from deleteTestReportFileToItemInputTestDetail.");
         return new ResponseEntity(NO_CONTENT);

--- a/src/main/java/com/mes/mesBackend/controller/PartInputTestRequestController.java
+++ b/src/main/java/com/mes/mesBackend/controller/PartInputTestRequestController.java
@@ -29,6 +29,8 @@ import javax.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PART;
+
 // 14-1. 검사의뢰 등록
 @RequestMapping(value = "/part-input-test-requests")
 @Tag(name = "part-input-test-request", description = "14-1. 검사의뢰등록 API")
@@ -37,7 +39,7 @@ import java.util.List;
 @Slf4j
 @RequiredArgsConstructor
 public class PartInputTestRequestController {
-    private final InputTestRequestService outsourcingInputTestRequestService;
+    private final InputTestRequestService inputTestRequestService;
     private final LogService logService;
     private final Logger logger = LoggerFactory.getLogger(PartInputTestRequestController.class);
     private CustomLogger cLogger;
@@ -56,7 +58,7 @@ public class PartInputTestRequestController {
             @RequestBody @Valid InputTestRequestCreateRequest inputTestRequestRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestRequestResponse inputTestRequest = outsourcingInputTestRequestService.createInputTestRequest(inputTestRequestRequest, true);
+        InputTestRequestResponse inputTestRequest = inputTestRequestService.createInputTestRequest(inputTestRequestRequest, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestRequest.getId() + " from createItemInputTestRequest.");
         return new ResponseEntity<>(inputTestRequest, HttpStatus.OK);
@@ -79,8 +81,9 @@ public class PartInputTestRequestController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "의뢰기간 fromDate") LocalDate fromDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "의뢰기간 toDate") LocalDate toDate,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
-    ) {
-        List<InputTestRequestResponse> inputTestRequests = outsourcingInputTestRequestService.getInputTestRequests(warehouseId, lotTypeId, itemNoAndName, testType, itemGroupId, requestType, fromDate, toDate, true);
+    ) throws NotFoundException {
+        List<InputTestRequestResponse> inputTestRequests = inputTestRequestService.getInputTestRequests(
+                warehouseId, lotTypeId, itemNoAndName, testType, itemGroupId, requestType, fromDate, toDate, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getItemInputTestRequests.");
         return new ResponseEntity<>(inputTestRequests, HttpStatus.OK);
@@ -100,7 +103,7 @@ public class PartInputTestRequestController {
             @PathVariable(value = "id") @Parameter(description = "검사의뢰 id") Long id,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        InputTestRequestResponse inputTestRequest = outsourcingInputTestRequestService.getInputTestRequestResponse(id, true);
+        InputTestRequestResponse inputTestRequest = inputTestRequestService.getInputTestRequestResponse(id, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the " + inputTestRequest.getId() + " from getItemInputTestRequest.");
         return new ResponseEntity<>(inputTestRequest, HttpStatus.OK);
@@ -122,7 +125,7 @@ public class PartInputTestRequestController {
             @RequestBody @Valid InputTestRequestUpdateRequest inputTestRequestUpdateRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestRequestResponse inputTestRequest = outsourcingInputTestRequestService.updateInputTestRequest(id, inputTestRequestUpdateRequest, true);
+        InputTestRequestResponse inputTestRequest = inputTestRequestService.updateInputTestRequest(id, inputTestRequestUpdateRequest, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is modified the " + inputTestRequest.getId() + " from updateItemInputTestRequest.");
         return new ResponseEntity<>(inputTestRequest, HttpStatus.OK);
@@ -142,7 +145,7 @@ public class PartInputTestRequestController {
             @PathVariable(value = "id") @Parameter(description = "검사의뢰 id") Long id,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        outsourcingInputTestRequestService.deleteInputTestRequest(id, true);
+        inputTestRequestService.deleteInputTestRequest(id, PART);
         cLogger = new MongoLogger(logger, "mongoTemplate");
         cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + id + " from deleteItemInputTestRequest.");
         return new ResponseEntity(HttpStatus.NO_CONTENT);

--- a/src/main/java/com/mes/mesBackend/controller/ProductInputTestEnrollmentController.java
+++ b/src/main/java/com/mes/mesBackend/controller/ProductInputTestEnrollmentController.java
@@ -1,0 +1,174 @@
+package com.mes.mesBackend.controller;
+
+import com.mes.mesBackend.dto.request.InputTestDetailRequest;
+import com.mes.mesBackend.dto.response.InputTestDetailResponse;
+import com.mes.mesBackend.dto.response.InputTestRequestInfoResponse;
+import com.mes.mesBackend.entity.enumeration.TestType;
+import com.mes.mesBackend.exception.BadRequestException;
+import com.mes.mesBackend.exception.NotFoundException;
+import com.mes.mesBackend.logger.CustomLogger;
+import com.mes.mesBackend.logger.LogService;
+import com.mes.mesBackend.logger.MongoLogger;
+import com.mes.mesBackend.service.InputTestDetailService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PRODUCT;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+// 16-2. 검사 등록
+@RequestMapping(value = "/product-input-test-enrollments")
+@Tag(name = "product-input-test-enrollment", description = "16-2. 검사등록 API")
+@RestController
+@SecurityRequirement(name = "Authorization")
+@Slf4j
+@RequiredArgsConstructor
+public class ProductInputTestEnrollmentController {
+    private final InputTestDetailService inputTestDetailService;
+    private final LogService logService;
+    private final Logger logger = LoggerFactory.getLogger(ProductInputTestEnrollmentController.class);
+    private CustomLogger cLogger;
+
+
+    // 검사요청정보 리스트 조회
+    // 검색조건: 창고 id, 품명|품목, 완료여부, 입고번호, 품목그룹 id, LOT 유형 id, 요청기간 from~toDate, 제조사 id
+    @GetMapping
+    @ResponseBody
+    @Operation(
+            summary = "검사요청정보 리스트 조회",
+            description = "검색조건: 창고 id, 품명|품목, 완료여부, 품목그룹 id, LOT 유형 id, 요청기간 from~toDate, 검사유형")
+    public ResponseEntity<List<InputTestRequestInfoResponse>> getProductInputTestRequestInfo(
+            @RequestParam(required = false) @Parameter(description = "창고 id") Long warehouseId,
+            @RequestParam(required = false) @Parameter(description = "품명|품번") String itemNoAndName,
+            @RequestParam(required = false) @Parameter(description = "완료여부") Boolean completionYn,
+            @RequestParam(required = false) @Parameter(description = "입고번호 (purchaseInputId)", hidden = true) Long purchaseInputNo,
+            @RequestParam(required = false) @Parameter(description = "품목그룹 id") Long itemGroupId,
+            @RequestParam(required = false) @Parameter(description = "LOT 유형 id") Long lotTypeId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "요청기간 fromDate") LocalDate fromDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "요청기간 toDate") LocalDate toDate,
+            @RequestParam(required = false) @Parameter(description = "제조사 id(clientId)", hidden = true) Long manufactureId,
+            @RequestParam(required = false) @Parameter(description = "검사유형") TestType testType,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException {
+        List<InputTestRequestInfoResponse> inputTestInfos = inputTestDetailService.getInputTestRequestInfo(warehouseId, itemNoAndName, completionYn, purchaseInputNo, itemGroupId, lotTypeId, fromDate, toDate, manufactureId, PRODUCT, testType);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getProductInputTestRequestInfo.");
+        return new ResponseEntity<>(inputTestInfos, HttpStatus.OK);
+    }
+
+    // 검사정보 생성
+    @Operation(summary = "검사정보 생성", description = "")
+    @PostMapping("/{input-test-request-id}/input-test-details")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "success"),
+                    @ApiResponse(responseCode = "400", description = "bad request"),
+                    @ApiResponse(responseCode = "404", description = "not found resource")
+            }
+    )
+    public ResponseEntity<InputTestDetailResponse> createProductInputTestDetail(
+            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+            @RequestBody @Valid InputTestDetailRequest inputTestDetailRequest,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException, BadRequestException {
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.createInputTestDetail(inputTestRequestId, inputTestDetailRequest, PRODUCT);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestDetail.getId() + " from createProductInputTestDetail.");
+        return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
+    }
+
+    // 검사정보 단일조회
+    @GetMapping("/{input-test-request-id}/input-test-details/{input-test-detail-id}")
+    @ResponseBody
+    @Operation(summary = "검사정보 단일조회", description = "")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "success"),
+                    @ApiResponse(responseCode = "404", description = "not found resource")
+            }
+    )
+    public ResponseEntity<InputTestDetailResponse> getProductInputTestDetail(
+            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException {
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.getInputTestDetail(inputTestRequestId, inputTestDetailId, PRODUCT);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the " + inputTestDetail.getId() + " from getProductInputTestDetail.");
+        return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
+    }
+
+    // 검사정보 전체조회
+    @GetMapping("/{input-test-request-id}/input-test-details")
+    @ResponseBody
+    @Operation(summary = "검사정보 전체조회", description = "")
+    public ResponseEntity<List<InputTestDetailResponse>> getProductInputTestDetails(
+            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException {
+        List<InputTestDetailResponse> inputTestDetails = inputTestDetailService.getInputTestDetails(inputTestRequestId, PRODUCT);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getProductInputTestDetails.");
+        return new ResponseEntity<>(inputTestDetails, HttpStatus.OK);
+    }
+
+    // 검사정보 수정
+    @PatchMapping("/{input-test-request-id}/input-test-details/{input-test-detail-id}")
+    @ResponseBody()
+    @Operation(summary = "검사정보 수정", description = "")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "success"),
+                    @ApiResponse(responseCode = "404", description = "not found resource"),
+                    @ApiResponse(responseCode = "400", description = "bad request")
+            }
+    )
+    public ResponseEntity<InputTestDetailResponse> updateProductInputTestDetail(
+            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
+            @RequestBody @Valid InputTestDetailRequest inputTestDetailRequest,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException, BadRequestException {
+        InputTestDetailResponse inputTestDetail = inputTestDetailService.updateInputTestDetail(inputTestRequestId, inputTestDetailId, inputTestDetailRequest, PRODUCT);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is modified the " + inputTestDetail.getId() + " from updateProductInputTestDetail.");
+        return new ResponseEntity<>(inputTestDetail, HttpStatus.OK);
+    }
+
+    // 검사정보 삭제
+    @DeleteMapping("/{input-test-request-id}/input-test-details/{input-test-detail-id}")
+    @ResponseBody()
+    @Operation(summary = "검사정보 삭제", description = "")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "204", description = "no content"),
+                    @ApiResponse(responseCode = "404", description = "not found resource")
+            }
+    )
+    public ResponseEntity<Void> deleteProductInputTestDetail(
+            @PathVariable(value = "input-test-request-id") @Parameter(description = "검사의뢰 id") Long inputTestRequestId,
+            @PathVariable(value = "input-test-detail-id") @Parameter(description = "검사정보 id") Long inputTestDetailId,
+            @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
+    ) throws NotFoundException {
+        inputTestDetailService.deleteInputTestDetail(inputTestRequestId, inputTestDetailId, PRODUCT);
+        cLogger = new MongoLogger(logger, "mongoTemplate");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + inputTestDetailId + " from deleteProductInputTestDetail.");
+        return new ResponseEntity(NO_CONTENT);
+    }
+}

--- a/src/main/java/com/mes/mesBackend/controller/ProductInputTestPerformanceController.java
+++ b/src/main/java/com/mes/mesBackend/controller/ProductInputTestPerformanceController.java
@@ -51,7 +51,7 @@ public class ProductInputTestPerformanceController {
             @RequestParam(required = false) @Parameter(description = "거래처 id") Long clientId,
             @RequestParam(required = false) @Parameter(description = "입고번호 (purchaseInputId)", hidden = true) Long purchaseInputNo,
             @RequestParam(required = false) @Parameter(description = "검사유형") TestType testType,
-            @RequestParam(required = false) @Parameter(description = "검사창고") Long wareHouseId,
+            @RequestParam(required = false) @Parameter(description = "입고창고") Long wareHouseId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) {
         List<InputTestPerformanceResponse> inputTestPerformanceResponses = inputTestPerformanceService.getInputTestPerformances(fromDate, toDate, itemNoAndName, clientId, purchaseInputNo, PRODUCT, testType, wareHouseId);

--- a/src/main/java/com/mes/mesBackend/controller/ProductInputTestPerformanceController.java
+++ b/src/main/java/com/mes/mesBackend/controller/ProductInputTestPerformanceController.java
@@ -1,7 +1,6 @@
 package com.mes.mesBackend.controller;
 
 import com.mes.mesBackend.dto.response.InputTestPerformanceResponse;
-import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.logger.CustomLogger;
 import com.mes.mesBackend.logger.LogService;
@@ -23,41 +22,41 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
-import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PART;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PRODUCT;
 
-// 14-3. 검사실적 조회
-@RequestMapping(value = "/part-input-test-performances")
-@Tag(name = "part-input-test-performance", description = "14-3. 검사실적 조회 API")
+// 16-4. 검사 현황 조회
+@RequestMapping(value = "/product-input-test-performances")
+@Tag(name = "product-input-test-performance", description = "16-4. 검사 현황 조회 API")
 @RestController
 @SecurityRequirement(name = "Authorization")
 @Slf4j
 @RequiredArgsConstructor
-public class PartInputTestPerformanceController {
+public class ProductInputTestPerformanceController {
     private final InputTestPerformanceService inputTestPerformanceService;
     private final LogService logService;
-    private final Logger logger = LoggerFactory.getLogger(PartInputTestPerformanceController.class);
+    private final Logger logger = LoggerFactory.getLogger(ProductInputTestPerformanceController.class);
     private CustomLogger cLogger;
 
-    // 검사실적조회
+    // 검사현황조회
     // 검색조건: 검사기간 fromDate~toDate, 품목 id, 거래처 id, 입고번호(구매입고 id)
     @GetMapping
     @ResponseBody
     @Operation(
-            summary = "검사실적조회",
+            summary = "검사현황조회",
             description = "검색조건: 검사기간 fromDate~toDate, 품명|품번, 거래처 id, 입고번호(구매입고 id)")
-    public ResponseEntity<List<InputTestPerformanceResponse>> getInputTestPerformances(
+    public ResponseEntity<List<InputTestPerformanceResponse>> getProductInputTestPerformances(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "검사기간 fromDate") LocalDate fromDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "검사기간 toDate") LocalDate toDate,
             @RequestParam(required = false) @Parameter(description = "품명|품번") String itemNoAndName,
             @RequestParam(required = false) @Parameter(description = "거래처 id") Long clientId,
-            @RequestParam(required = false) @Parameter(description = "입고번호 (purchaseInputId)") Long purchaseInputNo,
-            @RequestParam(required = false) @Parameter(description = "검사유형", hidden = true) TestType testType,
-            @RequestParam(required = false) @Parameter(description = "검사창고", hidden = true) Long wareHouseId,
+            @RequestParam(required = false) @Parameter(description = "입고번호 (purchaseInputId)", hidden = true) Long purchaseInputNo,
+            @RequestParam(required = false) @Parameter(description = "검사유형") TestType testType,
+            @RequestParam(required = false) @Parameter(description = "검사창고") Long wareHouseId,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) {
-        List<InputTestPerformanceResponse> inputTestPerformanceResponses = inputTestPerformanceService.getInputTestPerformances(fromDate, toDate, itemNoAndName, clientId, purchaseInputNo, PART, testType, wareHouseId);
+        List<InputTestPerformanceResponse> inputTestPerformanceResponses = inputTestPerformanceService.getInputTestPerformances(fromDate, toDate, itemNoAndName, clientId, purchaseInputNo, PRODUCT, testType, wareHouseId);
         cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getInputTestPerformances.");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getProductInputTestPerformances.");
         return new ResponseEntity<>(inputTestPerformanceResponses, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mes/mesBackend/controller/ProductInputTestRequestController.java
+++ b/src/main/java/com/mes/mesBackend/controller/ProductInputTestRequestController.java
@@ -3,7 +3,6 @@ package com.mes.mesBackend.controller;
 import com.mes.mesBackend.dto.request.InputTestRequestCreateRequest;
 import com.mes.mesBackend.dto.request.InputTestRequestUpdateRequest;
 import com.mes.mesBackend.dto.response.InputTestRequestResponse;
-import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.exception.BadRequestException;
 import com.mes.mesBackend.exception.NotFoundException;
@@ -18,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -29,22 +29,23 @@ import javax.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 
-import static com.mes.mesBackend.entity.enumeration.InputTestDivision.OUT_SOURCING;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PRODUCT;
 
-// 15-1. 외주수입검사의뢰 등록
-@RequestMapping(value = "/outsourcing-input-test-requests")
-@Tag(name = "outsourcing-input-test-request", description = "15-1. 외주수입검사의뢰등록 API")
+// 16-1. 검사의뢰 등록
+@RequestMapping(value = "/product-input-test-requests")
+@Tag(name = "product-input-test-request", description = "16-1. 검사의뢰등록 API")
 @RestController
 @SecurityRequirement(name = "Authorization")
+@Slf4j
 @RequiredArgsConstructor
-public class OutsourcingInputTestRequestController {
+public class ProductInputTestRequestController {
     private final InputTestRequestService inputTestRequestService;
     private final LogService logService;
-    private final Logger logger = LoggerFactory.getLogger(OutsourcingInputTestRequestController.class);
+    private final Logger logger = LoggerFactory.getLogger(ProductInputTestRequestController.class);
     private CustomLogger cLogger;
 
-    // 외주수입검사의뢰 생성
-    @Operation(summary = "외주수입검사의뢰 생성", description = "* testType 추후 변경 예정")
+    // 검사의뢰 생성
+    @Operation(summary = "검사의뢰 생성", description = "* testType 추후 변경 예정, 완제품인 lot id 만 등록가능")
     @PostMapping
     @ApiResponses(
             value = {
@@ -53,26 +54,24 @@ public class OutsourcingInputTestRequestController {
                     @ApiResponse(responseCode = "404", description = "not found resource")
             }
     )
-    public ResponseEntity<InputTestRequestResponse> createOutsourcingInputTestRequest(
+    public ResponseEntity<InputTestRequestResponse> createProductInputTestRequest(
             @RequestBody @Valid InputTestRequestCreateRequest inputTestRequestRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestRequestResponse outsourcingInputTestRequest =
-                inputTestRequestService.createInputTestRequest(inputTestRequestRequest, OUT_SOURCING);
+        InputTestRequestResponse inputTestRequest = inputTestRequestService.createInputTestRequest(inputTestRequestRequest, PRODUCT);
         cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " +
-                outsourcingInputTestRequest.getId() + " from createOutsourcingInputTestRequest.");
-        return new ResponseEntity<>(outsourcingInputTestRequest, HttpStatus.OK);
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is created the " + inputTestRequest.getId() + " from createProductInputTestRequest.");
+        return new ResponseEntity<>(inputTestRequest, HttpStatus.OK);
     }
 
-    // 외주수입검사의뢰 리스트 검색 조회
+    // 검사의뢰 리스트 검색 조회
     // 검색조건: 창고 id, LOT 유형 id, 품명|품목, 검사유형, 품목그룹, 요청유형, 의뢰기간
     @GetMapping
     @ResponseBody
     @Operation(
-            summary = "외주수입검사의뢰 리스트 조회",
+            summary = "검사의뢰 리스트 조회",
             description = "검색조건: 창고 id, LOT 유형 id, 품명|품목, 검사유형(추후 변경예정), 품목그룹 id, 요청유형, 의뢰기간")
-    public ResponseEntity<List<InputTestRequestResponse>> getOutsourcingInputTestRequests(
+    public ResponseEntity<List<InputTestRequestResponse>> getProductInputTestRequests(
             @RequestParam(required = false) @Parameter(description = "창고 id") Long warehouseId,
             @RequestParam(required = false) @Parameter(description = "LOT 유형 id") Long lotTypeId,
             @RequestParam(required = false) @Parameter(description = "품명|품번") String itemNoAndName,
@@ -83,37 +82,37 @@ public class OutsourcingInputTestRequestController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "의뢰기간 toDate") LocalDate toDate,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        List<InputTestRequestResponse> outsourcingInputTestRequests =
-                inputTestRequestService.getInputTestRequests(warehouseId, lotTypeId, itemNoAndName, testType, itemGroupId, requestType, fromDate, toDate, OUT_SOURCING);
+        List<InputTestRequestResponse> inputTestRequests = inputTestRequestService.getInputTestRequests(
+                warehouseId, lotTypeId, itemNoAndName, testType, itemGroupId, requestType, fromDate, toDate, PRODUCT);
         cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getOutsourcingInputTestRequests.");
-        return new ResponseEntity<>(outsourcingInputTestRequests, HttpStatus.OK);
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getProductInputTestRequests.");
+        return new ResponseEntity<>(inputTestRequests, HttpStatus.OK);
     }
 
-    // 외주수입검사의뢰 단일 조회
+    // 검사의뢰 단일 조회
     @GetMapping("/{id}")
     @ResponseBody()
-    @Operation(summary = "외주수입검사의뢰 단일 조회", description = "")
+    @Operation(summary = "검사의뢰 단일 조회", description = "")
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "success"),
                     @ApiResponse(responseCode = "404", description = "not found resource")
             }
     )
-    public ResponseEntity<InputTestRequestResponse> getOutsourcingInputTestRequest(
-            @PathVariable(value = "id") @Parameter(description = "외주수입검사의뢰 id") Long id,
+    public ResponseEntity<InputTestRequestResponse> getProductInputTestRequest(
+            @PathVariable(value = "id") @Parameter(description = "검사의뢰 id") Long id,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException {
-        InputTestRequestResponse outsourcingInputTestRequest = inputTestRequestService.getInputTestRequestResponse(id, OUT_SOURCING);
+        InputTestRequestResponse inputTestRequest = inputTestRequestService.getInputTestRequestResponse(id, PRODUCT);
         cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the " + outsourcingInputTestRequest.getId() + " from getOutsourcingInputTestRequest.");
-        return new ResponseEntity<>(outsourcingInputTestRequest, HttpStatus.OK);
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the " + inputTestRequest.getId() + " from getProductItemInputTestRequest.");
+        return new ResponseEntity<>(inputTestRequest, HttpStatus.OK);
     }
 
-    // 외주수입검사의뢰 수정
+    // 검사의뢰 수정
     @PatchMapping("/{id}")
     @ResponseBody()
-    @Operation(summary = "외주수입검사의뢰 수정", description = "* testType 추후 변경 예정")
+    @Operation(summary = "검사의뢰 수정", description = "* testType 추후 변경 예정")
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "success"),
@@ -121,34 +120,34 @@ public class OutsourcingInputTestRequestController {
                     @ApiResponse(responseCode = "400", description = "bad request")
             }
     )
-    public ResponseEntity<InputTestRequestResponse> updateOutsourcingInputTestRequest(
-            @PathVariable(value = "id") @Parameter(description = "외주수입검사의뢰 id") Long id,
+    public ResponseEntity<InputTestRequestResponse> updateProductInputTestRequest(
+            @PathVariable(value = "id") @Parameter(description = "검사의뢰 id") Long id,
             @RequestBody @Valid InputTestRequestUpdateRequest inputTestRequestUpdateRequest,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        InputTestRequestResponse outsourcingInputTestRequest = inputTestRequestService.updateInputTestRequest(id, inputTestRequestUpdateRequest, OUT_SOURCING);
+        InputTestRequestResponse inputTestRequest = inputTestRequestService.updateInputTestRequest(id, inputTestRequestUpdateRequest, PRODUCT);
         cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is modified the " + outsourcingInputTestRequest.getId() + " from updateOutsourcingInputTestRequest.");
-        return new ResponseEntity<>(outsourcingInputTestRequest, HttpStatus.OK);
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is modified the " + inputTestRequest.getId() + " from updateProductInputTestRequest.");
+        return new ResponseEntity<>(inputTestRequest, HttpStatus.OK);
     }
 
-    // 외주수입검사의뢰 삭제
+    // 검사의뢰 삭제
     @DeleteMapping("/{id}")
     @ResponseBody()
-    @Operation(summary = "외주수입검사의뢰 삭제", description = "")
+    @Operation(summary = "검사의뢰 삭제", description = "")
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "204", description = "no content"),
                     @ApiResponse(responseCode = "404", description = "not found resource")
             }
     )
-    public ResponseEntity<Void> deleteOutsourcingInputTestRequest(
-            @PathVariable(value = "id") @Parameter(description = "외주수입검사의뢰 id") Long id,
+    public ResponseEntity<Void> deleteProductInputTestRequest(
+            @PathVariable(value = "id") @Parameter(description = "검사의뢰 id") Long id,
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) throws NotFoundException, BadRequestException {
-        inputTestRequestService.deleteInputTestRequest(id, OUT_SOURCING);
+        inputTestRequestService.deleteInputTestRequest(id, PRODUCT);
         cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + id + " from deleteOutsourcingInputTestRequest.");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is deleted the " + id + " from deleteProductInputTestRequest.");
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/mes/mesBackend/controller/ProductInputTestScheduleController.java
+++ b/src/main/java/com/mes/mesBackend/controller/ProductInputTestScheduleController.java
@@ -1,8 +1,6 @@
 package com.mes.mesBackend.controller;
 
-import com.mes.mesBackend.dto.response.InputTestPerformanceResponse;
 import com.mes.mesBackend.dto.response.InputTestScheduleResponse;
-import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.logger.CustomLogger;
 import com.mes.mesBackend.logger.LogService;
@@ -24,20 +22,21 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
-import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PART;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PRODUCT;
 
-// 14-4. 검사대기 현황
-@RequestMapping(value = "/part-input-test-schedules")
-@Tag(name = "part-input-test-schedule", description = "14-4. 검사대기 현황 API")
+// 15-4. 검사대기 현황
+@RequestMapping(value = "/product-input-test-schedules")
+@Tag(name = "product-input-test-schedule", description = "16-5.. 검사대기 현황 API")
 @RestController
 @SecurityRequirement(name = "Authorization")
 @Slf4j
 @RequiredArgsConstructor
-public class PartInputTestScheduleController {
+public class ProductInputTestScheduleController {
     private final InputTestPerformanceService inputTestPerformanceService;
     private final LogService logService;
-    private final Logger logger = LoggerFactory.getLogger(PartInputTestScheduleController.class);
+    private final Logger logger = LoggerFactory.getLogger(ProductInputTestScheduleController.class);
     private CustomLogger cLogger;
+
 
     // 검사대기 현황 조회
     // 검색조건: 검사창고 id, 검사유형, 품명|품번, 거래처, 검사기간 fromDate~toDate
@@ -46,7 +45,7 @@ public class PartInputTestScheduleController {
     @Operation(
             summary = "검사대기 현황 조회",
             description = "검색조건: 검사창고 id, 검사유형, 품명|품번, 거래처, 검사요청기간 fromDate~toDate")
-    public ResponseEntity<List<InputTestScheduleResponse>> getPartInputTestSchedules(
+    public ResponseEntity<List<InputTestScheduleResponse>> getProductInputTestSchedules(
             @RequestParam(required = false) @Parameter(description = "검사창고 id") Long wareHouseId,
             @RequestParam(required = false) @Parameter(description = "검사유형") TestType testType,
             @RequestParam(required = false) @Parameter(description = "품명|품번") String itemNoAndName,
@@ -56,10 +55,10 @@ public class PartInputTestScheduleController {
             @RequestHeader(value = "Authorization", required = false) @Parameter(hidden = true) String tokenHeader
     ) {
         List<InputTestScheduleResponse> inputTestScheduleResponses = inputTestPerformanceService.getInputTestSchedules(
-                wareHouseId, testType, itemNoAndName, clientId, fromDate, toDate, PART
+                wareHouseId, testType, itemNoAndName, clientId, fromDate, toDate, PRODUCT
         );
         cLogger = new MongoLogger(logger, "mongoTemplate");
-        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getPartInputTestSchedules.");
+        cLogger.info(logService.getUserCodeFromHeader(tokenHeader) + " is viewed the list of from getProductInputTestSchedules.");
         return new ResponseEntity<>(inputTestScheduleResponses, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mes/mesBackend/dto/request/InputTestRequestCreateRequest.java
+++ b/src/main/java/com/mes/mesBackend/dto/request/InputTestRequestCreateRequest.java
@@ -5,12 +5,16 @@ import com.mes.mesBackend.entity.enumeration.TestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD;
 
 @Getter
 @Setter
-@Schema(description = "14-1.검사의뢰 등록")
+@Schema(description = "검사의뢰 등록")
 @JsonInclude(NON_NULL)
 public class InputTestRequestCreateRequest {
     @Schema(description = "lot id")
@@ -24,4 +28,8 @@ public class InputTestRequestCreateRequest {
 
     @Schema(description = "검사유형")
     TestType testType;
+
+    @Schema(description = "검사완료요청일")
+    @DateTimeFormat(pattern = YYYY_MM_DD)
+    LocalDate testCompletionRequestDate;
 }

--- a/src/main/java/com/mes/mesBackend/dto/request/InputTestRequestUpdateRequest.java
+++ b/src/main/java/com/mes/mesBackend/dto/request/InputTestRequestUpdateRequest.java
@@ -5,8 +5,12 @@ import com.mes.mesBackend.entity.enumeration.TestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD;
 
 @Getter
 @Setter
@@ -21,4 +25,8 @@ public class InputTestRequestUpdateRequest {
 
     @Schema(description = "검사유형")
     TestType testType;
+
+    @Schema(description = "검사완료요청일")
+    @DateTimeFormat(pattern = YYYY_MM_DD)
+    LocalDate testCompletionRequestDate;
 }

--- a/src/main/java/com/mes/mesBackend/dto/response/InputTestDetailResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/InputTestDetailResponse.java
@@ -1,6 +1,7 @@
 package com.mes.mesBackend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,6 +9,8 @@ import lombok.Setter;
 import java.time.LocalDate;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.OUT_SOURCING;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.PRODUCT;
 
 @Getter
 @Setter
@@ -52,4 +55,12 @@ public class InputTestDetailResponse {
 
     @Schema(description = "비고")
     String note;
+
+    public InputTestDetailResponse division(InputTestDivision inputTestDivision) {
+        if (inputTestDivision.equals(PRODUCT) || inputTestDivision.equals(OUT_SOURCING)) {
+            setCocFileUrl(null);
+            setTestReportFileUrl(null);
+        }
+        return this;
+    }
 }

--- a/src/main/java/com/mes/mesBackend/dto/response/InputTestPerformanceResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/InputTestPerformanceResponse.java
@@ -2,6 +2,8 @@ package com.mes.mesBackend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
+import com.mes.mesBackend.entity.enumeration.TestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.*;
 import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD;
 import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD_HH_MM;
 
@@ -81,10 +84,10 @@ public class InputTestPerformanceResponse {
     String user;
 
     @Schema(description = "시험성적서")
-    boolean testReportYn;
+    Boolean testReportYn;
 
     @Schema(description = "COC")
-    boolean cocYn;
+    Boolean cocYn;
 
     @Schema(description = "검사성적서 파일 url")
     String testReportFileUrl;
@@ -95,9 +98,38 @@ public class InputTestPerformanceResponse {
     @Schema(description = "비고")
     String note;
 
-    public InputTestPerformanceResponse division(boolean inputTestDivision) {
-        if (inputTestDivision) setOutsourcingOrderNo(null);
-        else setPurchaseOrderNo(null);
+    @Schema(description = "LOT 유형")
+    String lotType;
+
+    @Schema(description = "검사유형")
+    TestType testType;
+
+    @Schema(description = "입고창고")
+    String wareHouseName;
+
+    public InputTestPerformanceResponse division(InputTestDivision inputTestDivision) {
+        if (inputTestDivision.equals(PART)) {
+            setOutsourcingOrderNo(null);
+            setLotType(null);
+            setTestType(null);
+            setWareHouseName(null);
+        }
+        else if (inputTestDivision.equals(OUT_SOURCING)) {
+            setPurchaseOrderNo(null);
+            setLotType(null);
+            setTestType(null);
+            setWareHouseName(null);
+        } else if (inputTestDivision.equals(PRODUCT)) {
+            setRequestDate(null);
+            setItemForm(null);
+            setOutsourcingOrderNo(null);
+            setPurchaseOrderNo(null);
+            setItemManufacturerPartNo(null);
+            setTestProcess(null);
+            setTestCriteria(null);
+            setTestReportFileUrl(null);
+            setCocFileUrl(null);
+        }
         return this;
     }
 }

--- a/src/main/java/com/mes/mesBackend/dto/response/InputTestRequestInfoResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/InputTestRequestInfoResponse.java
@@ -1,16 +1,21 @@
 package com.mes.mesBackend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.mes.mesBackend.entity.enumeration.EnrollmentType;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.*;
+import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD;
 import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD_HH_MM;
 
 // 14-2. 검사등록
@@ -26,6 +31,9 @@ public class InputTestRequestInfoResponse {
     @Schema(description = "요청일시")
     @JsonFormat(pattern = YYYY_MM_DD_HH_MM, timezone = "Asia/Seoul")
     LocalDateTime requestDate;
+
+    @JsonIgnore
+    Long lotMasterId;
 
     @Schema(description = "LOT 번호")
     String lotNo;
@@ -78,8 +86,8 @@ public class InputTestRequestInfoResponse {
     @Schema(description = "검사수량")
     int testAmount;
 
-    @Schema(description = "재고수량")
-    int stockAmount;
+//    @Schema(description = "재고수량")
+//    int stockAmount;      0118 없애라고 하심
 
     @Schema(description = "요청수량")
     int requestAmount;
@@ -88,22 +96,49 @@ public class InputTestRequestInfoResponse {
     TestType testType;      // 다시 검토
 
     @Schema(description = "긴급여부")
-    boolean urgentYn;
+    Boolean urgentYn;
 
     @Schema(description = "시험성적서")
-    boolean testReportYn;
+    Boolean testReportYn;
 
     @Schema(description = "COC")
-    boolean coc;
+    Boolean coc;
 
-    public InputTestRequestInfoResponse division(boolean inputTestDivision) {
-        if (inputTestDivision) {
+    @Schema(description = "검사완료요청일")
+    @JsonFormat(pattern = YYYY_MM_DD, timezone = "Asia/Seoul")
+    LocalDate testCompletionRequestDate;
+
+    @Schema(description = "지시번호")
+    String workOrderNo;
+
+    public InputTestRequestInfoResponse division(InputTestDivision inputTestDivision) {
+        if (inputTestDivision.equals(PART)) {
             setOutsourcingInputNo(null);
             setOutsourcingProductionRequestNo(null);
+            setTestCompletionRequestDate(null);
+            setWorkOrderNo(null);
         }
-        else {
+        else if (inputTestDivision.equals(OUT_SOURCING)){
             setPurchaseInputNo(null);
             setPurchaseOrderNo(null);
+            setTestCompletionRequestDate(null);
+            setWorkOrderNo(null);
+            setUrgentYn(null);
+            setTestReportYn(null);
+            setCoc(null);
+        } else if (inputTestDivision.equals(PRODUCT)) {
+            setOutsourcingProductionRequestNo(null);
+            setOutsourcingInputNo(null);
+            setPurchaseInputNo(null);
+            setPurchaseOrderNo(null);
+            setItemManufacturerPartNo(null);
+            setTestProcess(null);
+            setTestProcess(null);
+            setTestType(null);
+            setLotMasterId(null);
+            setUrgentYn(null);
+            setTestReportYn(null);
+            setCoc(null);
         }
         return this;
     }

--- a/src/main/java/com/mes/mesBackend/dto/response/InputTestRequestResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/InputTestRequestResponse.java
@@ -2,14 +2,17 @@ package com.mes.mesBackend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.*;
 import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD;
 import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD_HH_MM;
 
@@ -64,13 +67,13 @@ public class InputTestRequestResponse {
     String testCriteria;
 
     @Schema(description = "긴급여부")
-    boolean urgentYn;
+    Boolean urgentYn;
 
     @Schema(description = "시험성적서")
-    boolean testReportYn;
+    Boolean testReportYn;
 
     @Schema(description = "COC")
-    boolean coc;
+    Boolean coc;
 
     @Schema(description = "요청일시")
     @JsonFormat(pattern = YYYY_MM_DD_HH_MM, timezone = "Asia/Seoul")
@@ -88,9 +91,31 @@ public class InputTestRequestResponse {
     @Schema(description = "검사요청")
     TestType testType;
 
-    public InputTestRequestResponse division(boolean inputTestDivision) {
-        if (inputTestDivision) setOutsourcingInputNo(null);
-        else setPurchaseInputNo(null);
+    @Schema(description = "검사완료요청일")
+    @JsonFormat(pattern = YYYY_MM_DD, timezone = "Asia/Seoul")
+    LocalDate testCompletionRequestDate;
+
+    @Schema(description = "지시번호")
+    String workOrderNo;
+
+    public InputTestRequestResponse division(InputTestDivision inputTestDivision) {
+        if (inputTestDivision.equals(PART)) {
+            setOutsourcingInputNo(null);
+            setTestCompletionRequestDate(null);
+            setWorkOrderNo(null);
+        } else if (inputTestDivision.equals(OUT_SOURCING)){
+            setPurchaseInputNo(null);
+            setTestCompletionRequestDate(null);
+            setWorkOrderNo(null);
+        } else if (inputTestDivision.equals(PRODUCT)) {
+            setOutsourcingInputNo(null);
+            setPurchaseInputNo(null);
+            setTestProcess(null);
+            setTestCriteria(null);
+            setCoc(null);
+            setTestReportYn(null);
+            setUrgentYn(null);
+        }
         return this;
     }
 }

--- a/src/main/java/com/mes/mesBackend/dto/response/InputTestRequestResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/InputTestRequestResponse.java
@@ -107,6 +107,9 @@ public class InputTestRequestResponse {
             setPurchaseInputNo(null);
             setTestCompletionRequestDate(null);
             setWorkOrderNo(null);
+            setCoc(null);
+            setTestReportYn(null);
+            setUrgentYn(null);
         } else if (inputTestDivision.equals(PRODUCT)) {
             setOutsourcingInputNo(null);
             setPurchaseInputNo(null);

--- a/src/main/java/com/mes/mesBackend/dto/response/InputTestScheduleResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/InputTestScheduleResponse.java
@@ -2,6 +2,7 @@ package com.mes.mesBackend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -11,10 +12,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.*;
 import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD_HH_MM;
 
 // 14-4. 검사대기 현황
 // 15-4. 검사대기 현황
+// 16-5. 검사대기 현황
 @Getter
 @Setter
 @Schema(description = "검사대기 현황")
@@ -56,16 +59,19 @@ public class InputTestScheduleResponse {
     @Schema(description = "창고")
     String wareHouseName;
 
-    @Schema(description = "구매입고 거래처")
+    @Schema(description = "거래처")
     String clientName;
 
     @Schema(description = "요청번호(검사의뢰 고유아이디)")
     Long inputTestRequestId;
 
-    public InputTestScheduleResponse division(boolean inputTestDivision) {
-        if (inputTestDivision) {
+    public InputTestScheduleResponse division(InputTestDivision inputTestDivision) {
+        if (inputTestDivision.equals(PART)) {
             setOutsourcingPeriodDate(null);
-        } else {
+        } else if (inputTestDivision.equals(OUT_SOURCING)){
+            setPurchaseInputPeriodDate(null);
+        } else if (inputTestDivision.equals(PRODUCT)) {
+            setOutsourcingPeriodDate(null);
             setPurchaseInputPeriodDate(null);
         }
         return this;

--- a/src/main/java/com/mes/mesBackend/dto/response/ProductInputTestRequestResponse.java
+++ b/src/main/java/com/mes/mesBackend/dto/response/ProductInputTestRequestResponse.java
@@ -1,0 +1,68 @@
+package com.mes.mesBackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mes.mesBackend.entity.enumeration.TestType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD;
+import static com.mes.mesBackend.helper.Constants.YYYY_MM_DD_HH_MM;
+
+@Getter
+@Setter
+@Schema(description = "16-1. 검사의뢰 등록")
+@JsonInclude(NON_NULL)
+public class ProductInputTestRequestResponse {
+    @Schema(description = "고유아이디")
+    Long id;
+
+    @Schema(description = "검사유형")
+    TestType testType;
+
+    @Schema(description = "LOT 고유아이디")
+    Long lotId;
+
+    @Schema(description = "LOT 번호")
+    String lotNo;
+
+    @Schema(description = "지시번호")
+    String workOrderNo;
+
+    @Schema(description = "품번")
+    String itemNo;
+
+    @Schema(description = "품명")
+    String itemName;
+
+    @Schema(description = "제조사 품번")
+    String itemManufacturerPartNo;
+
+    @Schema(description = "거래처")
+    String clientName;
+
+    @Schema(description = "창고")
+    String wareHouseName;
+
+    @Schema(description = "품목형태")
+    String itemForm;        // 품목형태
+
+    @Schema(description = "요청유형")
+    TestType requestType;
+
+    @Schema(description = "요청일시")
+    @JsonFormat(pattern = YYYY_MM_DD_HH_MM, timezone = "Asia/Seoul")
+    LocalDateTime requestDate;
+
+
+    @Schema(description = "요청수량")
+    int requestAmount;
+
+    @Schema(description = "검사수량")
+    int testAmount;
+}

--- a/src/main/java/com/mes/mesBackend/entity/InputTestRequest.java
+++ b/src/main/java/com/mes/mesBackend/entity/InputTestRequest.java
@@ -1,5 +1,6 @@
 package com.mes.mesBackend.entity;
 
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.InputTestState;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,9 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.time.LocalDate;
+
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.*;
 import static com.mes.mesBackend.entity.enumeration.InputTestState.*;
 import static com.mes.mesBackend.entity.enumeration.TestType.NO_TEST;
 import static javax.persistence.EnumType.STRING;
@@ -50,34 +54,33 @@ public class InputTestRequest extends BaseTimeEntity {
     @Column(name = "DELETE_YN", columnDefinition = "bit(1) COMMENT '삭제여부'", nullable = false)
     private boolean deleteYn = false;  // 삭제여부
 
-    @Column(name = "INPUT_TEST_DIVISION", columnDefinition = "bit(1) COMMENT '외주수입검사, 부품수입검사 구분'", nullable = false)
-    private boolean inputTestDivision;      // 부품수입검사 true, 외주수입검사: false
+    @Enumerated(STRING)
+    @Column(name = "INPUT_TEST_DIVISION", columnDefinition = "varchar(255) COMMENT '외주수입검사, 부품수입검사, 제품검사 구분'", nullable = false)
+    private InputTestDivision inputTestDivision;
 
-    // 14-1. 부품수입검사요청 등록
-    public void createItemInputRequest(LotMaster lotMaster) {
+    @Column(name = "TEST_COMPLETION_REQUEST_DATE", columnDefinition = "datetime COMMENT '검사완료요청일'")
+    private LocalDate testCompletionRequestDate;
+
+    public void createInputTestRequest(LotMaster lotMaster, InputTestDivision inputTestDivision, LocalDate testCompletionRequestDate) {
         setLotMaster(lotMaster);
         setInputTestState(SCHEDULE);
-        setInputTestDivision(true);
+        setInputTestDivision(inputTestDivision);
+        if (inputTestDivision.equals(PRODUCT)) {
+            setTestCompletionRequestDate(testCompletionRequestDate);
+        } else
+            setTestCompletionRequestDate(null);
     }
 
-    // 15-1. 외주수입검사요청 등록
-    public void createOutsourcingInputRequest(LotMaster lotMaster) {
-        setLotMaster(lotMaster);
-        setInputTestState(SCHEDULE);
-        setInputTestDivision(false);
-    }
-
-    public void update(InputTestRequest newInputTestRequest) {
+    public void update(InputTestRequest newInputTestRequest, InputTestDivision inputTestDivision) {
         setRequestType(newInputTestRequest.requestType);
         setRequestAmount(newInputTestRequest.requestAmount);
         setTestType(newInputTestRequest.testType);
+        if (inputTestDivision.equals(PRODUCT)) {
+            setTestCompletionRequestDate(newInputTestRequest.testCompletionRequestDate);
+        }
     }
 
     public void delete() {
         setDeleteYn(true);
-    }
-
-    public void changedSchedule() {
-        setInputTestState(SCHEDULE);
     }
 }

--- a/src/main/java/com/mes/mesBackend/entity/ProductionPerformance.java
+++ b/src/main/java/com/mes/mesBackend/entity/ProductionPerformance.java
@@ -63,4 +63,8 @@ public class ProductionPerformance extends BaseTimeEntity {
     // 삭제여부
     @Column(name = "DELETE_YN", columnDefinition = "bit(1) COMMENT '삭제여부'", nullable = false)
     private boolean deleteYn;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "LOT_MASTER", columnDefinition = "bigint COMMENT 'lot master'")
+    private LotMaster lotMaster;
 }

--- a/src/main/java/com/mes/mesBackend/entity/enumeration/InputTestDivision.java
+++ b/src/main/java/com/mes/mesBackend/entity/enumeration/InputTestDivision.java
@@ -1,0 +1,11 @@
+package com.mes.mesBackend.entity.enumeration;
+
+// 검사요청 구분
+/*
+* PART : 부품수입검사
+* OUT_SOURCING : 외주수입검사
+* PRODUCT : 제품검사
+* */
+public enum InputTestDivision {
+    PART, OUT_SOURCING, PRODUCT
+}

--- a/src/main/java/com/mes/mesBackend/helper/Constants.java
+++ b/src/main/java/com/mes/mesBackend/helper/Constants.java
@@ -7,4 +7,5 @@ public class Constants {
     public static final String ASIA_SEOUL = "Asia/Seoul";
     public static final String YYMMDD = "yyMMdd";
     public static final String LOT_DEFAULT_SEQ = String.format("%04d", 0);
+    public static final String PRODUCT_ITEM_ACCOUNT = "완제품";
 }

--- a/src/main/java/com/mes/mesBackend/repository/custom/InputTestDetailRepositoryCustom.java
+++ b/src/main/java/com/mes/mesBackend/repository/custom/InputTestDetailRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.mes.mesBackend.dto.response.InputTestDetailResponse;
 import com.mes.mesBackend.dto.response.InputTestPerformanceResponse;
 import com.mes.mesBackend.dto.response.InputTestRequestInfoResponse;
 import com.mes.mesBackend.dto.response.InputTestScheduleResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 
 import java.time.LocalDate;
@@ -24,10 +25,11 @@ public interface InputTestDetailRepositoryCustom {
             LocalDate fromDate,
             LocalDate toDate,
             Long manufactureId,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision,
+            TestType testType
     );
     // 검사상세정보 단일조회
-    Optional<InputTestDetailResponse> findDetailByInputTestRequestIdAndInputTestDetailIdAndDeleteYnFalse(Long inputTestRequestId, Long inputTestDetailId, boolean inputTestDivision);
+    Optional<InputTestDetailResponse> findDetailByInputTestRequestIdAndInputTestDetailIdAndDeleteYnFalse(Long inputTestRequestId, Long inputTestDetailId, InputTestDivision inputTestDivision);
     // 검사상세정보 전체 조회
     List<InputTestDetailResponse> findDetailsByInputTestRequestIdAndDeleteYnFalse(Long inputTestRequestId);
     // 검사요청정보에 해당하는 검사정보의 모든 검사수량
@@ -47,7 +49,9 @@ public interface InputTestDetailRepositoryCustom {
             String itemNoAndName,
             Long clientId,
             Long purchaseInputNo,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision,
+            TestType testType,
+            Long wareHouseId
     );
     // 14-4. 검사대기현황, 15-4. 검사대기현황
     // 검색조건: 검사창고 id, 검사유형, 품명|품번, 거래처, 검사기간 fromDate~toDate
@@ -58,6 +62,6 @@ public interface InputTestDetailRepositoryCustom {
             Long clientId,
             LocalDate fromDate,
             LocalDate toDate,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     );
 }

--- a/src/main/java/com/mes/mesBackend/repository/custom/InputTestRequestRepositoryCustom.java
+++ b/src/main/java/com/mes/mesBackend/repository/custom/InputTestRequestRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.mes.mesBackend.repository.custom;
 
 import com.mes.mesBackend.dto.response.InputTestRequestResponse;
 import com.mes.mesBackend.entity.InputTestRequest;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 
 import java.time.LocalDate;
@@ -11,7 +12,7 @@ import java.util.Optional;
 // 14-1. 검사의뢰 등록
 public interface InputTestRequestRepositoryCustom {
     // 검사의뢰등록 response 단일 조회 및 예외
-    Optional<InputTestRequestResponse> findResponseByIdAndDeleteYnFalse(Long id, boolean inputTestDivision);
+    Optional<InputTestRequestResponse> findResponseByIdAndDeleteYnFalse(Long id, InputTestDivision inputTestDivision);
     // 검사의뢰 리스트 검색 조회
     // 검색조건: 창고 id, LOT 유형 id, 품명|품목, 검사유형, 품목그룹, 요청유형, 의뢰기간
     List<InputTestRequestResponse> findAllByCondition(
@@ -23,11 +24,13 @@ public interface InputTestRequestRepositoryCustom {
             TestType requestType,
             LocalDate fromDate,
             LocalDate toDate,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     );
     // LOT Master 의 재고수량
     // inputTestService.createInputTest 에서 사용
-    Integer findLotMasterInputAmountByLotMasterId(Long lotMasterId);
+    Integer findLotMasterStockAmountByLotMasterId(Long lotMasterId);
     // 검사요청상태값 별 검사요청 조회
-    Optional<InputTestRequest> findByIdAndInputTestDivisionAndDeleteYnFalse(Long inputTestRequestId, boolean inputTestDivision);
+    Optional<InputTestRequest> findByIdAndInputTestDivisionAndDeleteYnFalse(Long inputTestRequestId, InputTestDivision inputTestDivision);
+    // lot id 로 생산실적의 workOrderDetailNo 조회
+    Optional<String> findWorkOrderNoByLotId(Long lotMasterId);
 }

--- a/src/main/java/com/mes/mesBackend/service/InputTestDetailService.java
+++ b/src/main/java/com/mes/mesBackend/service/InputTestDetailService.java
@@ -3,6 +3,8 @@ package com.mes.mesBackend.service;
 import com.mes.mesBackend.dto.request.InputTestDetailRequest;
 import com.mes.mesBackend.dto.response.InputTestDetailResponse;
 import com.mes.mesBackend.dto.response.InputTestRequestInfoResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
+import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.exception.BadRequestException;
 import com.mes.mesBackend.exception.NotFoundException;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,6 +15,7 @@ import java.util.List;
 
 // 14-2. 검사 등록
 // 15-2. 검사 등록
+// 16-2. 검사 등록
 public interface InputTestDetailService {
     // 검사요청정보 리스트 조회
     // 검색조건: 창고 id, 품명|품목, 완료여부, 입고번호, 품목그룹 id, LOT 유형 id, 요청기간 from~toDate, 제조사 id
@@ -26,22 +29,23 @@ public interface InputTestDetailService {
             LocalDate fromDate,
             LocalDate toDate,
             Long manufactureId,
-            boolean inputTestDivision
-    );
+            InputTestDivision inputTestDivision,
+            TestType testType
+    ) throws NotFoundException;
     // 검사정보 생성
-    InputTestDetailResponse createInputTestDetail(Long inputTestRequestId, InputTestDetailRequest inputTestDetailRequest, boolean inputTestDivision) throws NotFoundException, BadRequestException;
+    InputTestDetailResponse createInputTestDetail(Long inputTestRequestId, InputTestDetailRequest inputTestDetailRequest, InputTestDivision inputTestDivision) throws NotFoundException, BadRequestException;
     // 검사정보 단일조회
-    InputTestDetailResponse getInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, boolean inputTestDivision) throws NotFoundException;
+    InputTestDetailResponse getInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, InputTestDivision inputTestDivision) throws NotFoundException;
     // 검사정보 전체조회
-    List<InputTestDetailResponse> getInputTestDetails(Long inputTestRequestId, boolean inputTestDivision) throws NotFoundException;
+    List<InputTestDetailResponse> getInputTestDetails(Long inputTestRequestId, InputTestDivision inputTestDivision) throws NotFoundException;
     // 검사정보 수정
-    InputTestDetailResponse updateInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, InputTestDetailRequest inputTestDetailRequest, boolean inputTestDivision) throws NotFoundException, BadRequestException;
+    InputTestDetailResponse updateInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, InputTestDetailRequest inputTestDetailRequest, InputTestDivision inputTestDivision) throws NotFoundException, BadRequestException;
     // 검사정보 삭제
-    void deleteInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, boolean inputTestDivision) throws NotFoundException;
+    void deleteInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, InputTestDivision inputTestDivision) throws NotFoundException;
     // 검사성적서 파일
-    InputTestDetailResponse createTestReportFileToInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, MultipartFile testReportFile, boolean inputTestDivision) throws NotFoundException, BadRequestException, IOException;
+    InputTestDetailResponse createTestReportFileToInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, MultipartFile testReportFile, InputTestDivision inputTestDivision) throws NotFoundException, BadRequestException, IOException;
     // COC 파일 추가
-    InputTestDetailResponse createCocFileToInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, MultipartFile cocFile, boolean inputTestDivision) throws NotFoundException, BadRequestException, IOException;
+    InputTestDetailResponse createCocFileToInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, MultipartFile cocFile, InputTestDivision inputTestDivision) throws NotFoundException, BadRequestException, IOException;
     // 파일 삭제
-    void deleteTestReportFileAndCocFileToInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, boolean testReportDeleteYn, boolean cocDeleteYn, boolean inputTestDivision) throws NotFoundException;
+    void deleteTestReportFileAndCocFileToInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, boolean testReportDeleteYn, boolean cocDeleteYn, InputTestDivision inputTestDivision) throws NotFoundException;
 }

--- a/src/main/java/com/mes/mesBackend/service/InputTestPerformanceService.java
+++ b/src/main/java/com/mes/mesBackend/service/InputTestPerformanceService.java
@@ -2,6 +2,7 @@ package com.mes.mesBackend.service;
 
 import com.mes.mesBackend.dto.response.InputTestPerformanceResponse;
 import com.mes.mesBackend.dto.response.InputTestScheduleResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 
 import java.time.LocalDate;
@@ -9,6 +10,7 @@ import java.util.List;
 
 // 14-3. 검사실적 조회
 // 15-3. 검사실적 조회
+// 16-4. 검사 현황 조회
 public interface InputTestPerformanceService {
     // 검사실적조회
     // 검색조건: 검사기간 fromDate~toDate, 품목 id, 거래처 id, 입고번호(구매입고 id)
@@ -18,7 +20,9 @@ public interface InputTestPerformanceService {
             String itemNoAndName,
             Long clientId,
             Long purchaseInputNo,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision,
+            TestType testType,
+            Long wareHouseId
     );
     // 검사대기 현황 조회
     // 검색조건: 검사창고 id, 검사유형, 품명|품번, 거래처, 검사기간 fromDate~toDate
@@ -29,6 +33,6 @@ public interface InputTestPerformanceService {
             Long clientId,
             LocalDate fromDate,
             LocalDate toDate,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     );
 }

--- a/src/main/java/com/mes/mesBackend/service/InputTestRequestService.java
+++ b/src/main/java/com/mes/mesBackend/service/InputTestRequestService.java
@@ -4,6 +4,7 @@ import com.mes.mesBackend.dto.request.InputTestRequestCreateRequest;
 import com.mes.mesBackend.dto.request.InputTestRequestUpdateRequest;
 import com.mes.mesBackend.dto.response.InputTestRequestResponse;
 import com.mes.mesBackend.entity.InputTestRequest;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.exception.BadRequestException;
 import com.mes.mesBackend.exception.NotFoundException;
@@ -11,11 +12,15 @@ import com.mes.mesBackend.exception.NotFoundException;
 import java.time.LocalDate;
 import java.util.List;
 
+// 16-1. 제품검사의뢰 등록
 // 15-1. 외주수입검사의뢰 등록
 // 14-1. 부품수입검사의뢰 등록
 public interface InputTestRequestService {
     // 검사의뢰 생성
-    InputTestRequestResponse createInputTestRequest(InputTestRequestCreateRequest inputTestRequestRequest, boolean inputTestDivision) throws BadRequestException, NotFoundException;
+    InputTestRequestResponse createInputTestRequest(
+            InputTestRequestCreateRequest inputTestRequestRequest,
+            InputTestDivision inputTestDivision
+    ) throws BadRequestException, NotFoundException;
     // 검사의뢰 리스트 검색 조회
     // 검색조건: 창고 id, LOT 유형 id, 품명|품목, 검사유형, 품목그룹, 요청유형, 의뢰기간
     List<InputTestRequestResponse> getInputTestRequests(
@@ -27,14 +32,18 @@ public interface InputTestRequestService {
             TestType requestType,
             LocalDate fromDate,
             LocalDate toDate,
-            boolean inputTestDivision
-    );
+            InputTestDivision inputTestDivision
+    ) throws NotFoundException;
     // 검사의뢰 단일 조회 및 예외
-    InputTestRequestResponse getInputTestRequestResponse(Long id, boolean inputTestDivision) throws NotFoundException;
+    InputTestRequestResponse getInputTestRequestResponse(Long id, InputTestDivision inputTestDivision) throws NotFoundException;
     // 검사의뢰 수정
-    InputTestRequestResponse updateInputTestRequest(Long id, InputTestRequestUpdateRequest inputTestRequestUpdateRequest, boolean inputTestDivision) throws BadRequestException, NotFoundException;
+    InputTestRequestResponse updateInputTestRequest(
+            Long id,
+            InputTestRequestUpdateRequest inputTestRequestUpdateRequest,
+            InputTestDivision inputTestDivision
+    ) throws BadRequestException, NotFoundException;
     // 검사의뢰 삭제
-    void deleteInputTestRequest(Long id, boolean inputTestDivision) throws NotFoundException, BadRequestException;
+    void deleteInputTestRequest(Long id, InputTestDivision inputTestDivision) throws NotFoundException, BadRequestException;
     // 검사의뢰 단일 조회 및 예외
-    InputTestRequest getInputTestRequestOrThrow(Long id, boolean inputTestDivision) throws NotFoundException;
+    InputTestRequest getInputTestRequestOrThrow(Long id, InputTestDivision inputTestDivision) throws NotFoundException;
 }

--- a/src/main/java/com/mes/mesBackend/service/impl/InputTestDetailServiceImpl.java
+++ b/src/main/java/com/mes/mesBackend/service/impl/InputTestDetailServiceImpl.java
@@ -7,6 +7,8 @@ import com.mes.mesBackend.entity.InputTestDetail;
 import com.mes.mesBackend.entity.InputTestRequest;
 import com.mes.mesBackend.entity.LotMaster;
 import com.mes.mesBackend.entity.User;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
+import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.exception.BadRequestException;
 import com.mes.mesBackend.exception.NotFoundException;
 import com.mes.mesBackend.helper.AmountHelper;
@@ -27,11 +29,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.mes.mesBackend.entity.enumeration.InputTestDivision.*;
 import static com.mes.mesBackend.entity.enumeration.InputTestState.*;
 import static com.mes.mesBackend.entity.enumeration.ItemLogType.BAD_AMOUNT;
 
 // 14-2. 검사 등록
 // 15-2. 검사 등록
+// 16-2. 검사 등록
 @Service
 @RequiredArgsConstructor
 public class InputTestDetailServiceImpl implements InputTestDetailService {
@@ -57,20 +61,21 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
             LocalDate fromDate,
             LocalDate toDate,
             Long manufactureId,
-            boolean inputTestDivision
-    ) {
-        return inputTestDetailRepo.findInputTestRequestInfoResponseByCondition(
-                warehouseId,
-                itemNoAndName,
-                completionYn,
-                purchaseInputNo,
-                itemGroupId,
-                lotTypeId,
-                fromDate,
-                toDate,
-                manufactureId,
-                inputTestDivision
-        ).stream().map(res -> res.division(inputTestDivision)).collect(Collectors.toList());
+            InputTestDivision inputTestDivision,
+            TestType testType
+    ) throws NotFoundException {
+        List<InputTestRequestInfoResponse> responses = inputTestDetailRepo.findInputTestRequestInfoResponseByCondition(
+                warehouseId, itemNoAndName, completionYn, purchaseInputNo, itemGroupId, lotTypeId, fromDate, toDate, manufactureId, inputTestDivision, testType
+        );
+        for (InputTestRequestInfoResponse response : responses) {
+            int testAmount = inputTestDetailRepo.findTestAmountByInputTestRequestId(response.getId()).stream().mapToInt(Integer::intValue).sum();
+            response.setTestAmount(testAmount);
+            if (inputTestDivision.equals(PRODUCT)) {
+                    String workOrderNo = inputTestRequestRepo.findWorkOrderNoByLotId(response.getLotMasterId()).orElseThrow(() -> new NotFoundException("lot 에 해당하는 작업지시가 없음."));
+                    response.setWorkOrderNo(workOrderNo);
+                }
+            }
+        return responses.stream().map(res -> res.division(inputTestDivision)).collect(Collectors.toList());
     }
 
     /*
@@ -83,7 +88,7 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
     public InputTestDetailResponse createInputTestDetail(
             Long inputTestRequestId,
             InputTestDetailRequest inputTestDetailRequest,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     ) throws NotFoundException, BadRequestException {
         int inputFairQualityAmount = inputTestDetailRequest.getFairQualityAmount();
         int inputIncongruityAmount = inputTestDetailRequest.getIncongruityAmount();
@@ -122,24 +127,29 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
         inputTestDetailRepo.save(inputTestDetail);       // 검사상세정보 저장
         inputTestRequestRepo.save(inputTestRequest);     // 검사의뢰요청 저장
         // 수량변동에 대한 기록저장
-        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, inputTestDetail.getIncongruityAmount(), !inputTestDivision);
+        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, inputTestDetail.getIncongruityAmount(), inputTestDivision.equals(OUT_SOURCING));
         return getInputTestDetail(inputTestRequestId, inputTestDetail.getId(), inputTestDivision);
     }
 
     // 검사정보 단일조회
     @Override
-    public InputTestDetailResponse getInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, boolean inputTestDivision) throws NotFoundException {
+    public InputTestDetailResponse getInputTestDetail(
+            Long inputTestRequestId,
+            Long inputTestDetailId,
+            InputTestDivision inputTestDivision
+    ) throws NotFoundException {
         return inputTestDetailRepo.findDetailByInputTestRequestIdAndInputTestDetailIdAndDeleteYnFalse(inputTestRequestId, inputTestDetailId, inputTestDivision)
                 .orElseThrow(() -> new NotFoundException("inputTestDetail does not exist. " +
                         "input inputTestRequestId: " + inputTestRequestId + ", " +
-                        "input inputTestDetailId: " + inputTestDetailId));
+                        "input inputTestDetailId: " + inputTestDetailId)).division(inputTestDivision);
     }
 
     // 검사정보 전체조회
     @Override
-    public List<InputTestDetailResponse> getInputTestDetails(Long inputTestRequestId, boolean inputTestDivision) throws NotFoundException {
+    public List<InputTestDetailResponse> getInputTestDetails(Long inputTestRequestId, InputTestDivision inputTestDivision) throws NotFoundException {
         InputTestRequest inputTestRequest = inputTestRequestService.getInputTestRequestOrThrow(inputTestRequestId, inputTestDivision);
-        return inputTestDetailRepo.findDetailsByInputTestRequestIdAndDeleteYnFalse(inputTestRequest.getId());
+        return inputTestDetailRepo.findDetailsByInputTestRequestIdAndDeleteYnFalse(inputTestRequest.getId())
+                .stream().map(res -> res.division(inputTestDivision)).collect(Collectors.toList());
     }
 
     // 검사정보 수정
@@ -153,7 +163,7 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
             Long inputTestRequestId,
             Long inputTestDetailId,
             InputTestDetailRequest inputTestDetailRequest,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     ) throws NotFoundException, BadRequestException {
         int newTestAmount = inputTestDetailRequest.getTestAmount();
         int newFairQualityAmount = inputTestDetailRequest.getFairQualityAmount();
@@ -206,14 +216,14 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
         lotMasterRepo.save(lotMaster);
 
         // 수량변동에 대한 기록저장
-        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, (findIncongruityAmount - newIncongruityAmount) * -1, !inputTestDivision);
-        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, (findFairQualityAmount - newFairQualityAmount) * -1, !inputTestDivision);
+        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, (findIncongruityAmount - newIncongruityAmount) * -1, inputTestDivision.equals(OUT_SOURCING));
+        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, (findFairQualityAmount - newFairQualityAmount) * -1, inputTestDivision.equals(OUT_SOURCING));
         return getInputTestDetail(inputTestRequestId, inputTestDetailId, inputTestDivision);
     }
 
     // 검사정보 삭제
     @Override
-    public void deleteInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, boolean inputTestDivision) throws NotFoundException {
+    public void deleteInputTestDetail(Long inputTestRequestId, Long inputTestDetailId, InputTestDivision inputTestDivision) throws NotFoundException {
         InputTestRequest inputTestRequest = inputTestRequestService.getInputTestRequestOrThrow(inputTestRequestId, inputTestDivision);
         InputTestDetail findInputTestDetail = getInputTestDetailOrThrow(inputTestRequestId, inputTestDetailId, inputTestDivision);
 
@@ -238,8 +248,8 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
         inputTestRequestRepo.save(inputTestRequest);
 
         // 수량변동에 대한 기록저장
-        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, findIncongruityAmount * -1, !inputTestDivision);
-        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, findFairQualityAmount * -1, !inputTestDivision);
+        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, findIncongruityAmount * -1, inputTestDivision.equals(OUT_SOURCING));
+        amountHelper.amountUpdate(lotMaster.getItem().getId(), lotMaster.getWareHouse().getId(), null, BAD_AMOUNT, findFairQualityAmount * -1, inputTestDivision.equals(OUT_SOURCING));
 
         lotMasterRepo.save(lotMaster);
     }
@@ -251,13 +261,13 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
             Long inputTestRequestId,
             Long inputTestDetailId,
             MultipartFile testReportFile,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     ) throws NotFoundException, BadRequestException, IOException {
         InputTestDetail inputTestDetail = getInputTestDetailOrThrow(inputTestRequestId, inputTestDetailId, inputTestDivision);
-        String itemTestReportFileName = "item-input-test/" + inputTestDetail.getId() + "/test-report-files/";
+        String partTestReportFileName = "part-input-test/" + inputTestDetail.getId() + "/test-report-files/";
         String outsourcingTestReportFileName = "outsourcing-input-test/" + inputTestDetail.getId() + "/test-report-files/";
-        // inputTestDivison 따라서 파일명 다르게 리턴
-        String testReportFileName = inputTestDivision ? itemTestReportFileName : outsourcingTestReportFileName;
+        // inputTestDivision 따라서 파일명 다르게 리턴
+        String testReportFileName = inputTestDivision.equals(PART) ? partTestReportFileName : outsourcingTestReportFileName;
 
         String testReportFileUrl = s3Uploader.upload(testReportFile, testReportFileName);
         inputTestDetail.setTestReportFileUrl(testReportFileUrl);
@@ -273,13 +283,13 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
             Long inputTestRequestId,
             Long inputTestDetailId,
             MultipartFile cocFile,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     ) throws NotFoundException, BadRequestException, IOException {
         InputTestDetail inputTestDetail = getInputTestDetailOrThrow(inputTestRequestId, inputTestDetailId, inputTestDivision);
-        String itemCocFileName = "item-input-test/" + inputTestDetail.getId() + "/coc-files/";
+        String partCocFileName = "part-input-test/" + inputTestDetail.getId() + "/coc-files/";
         String outsourcingCocFileName = "outsourcing-input-test/" + inputTestDetail.getId() + "/coc-files/";
 
-        String cocFileName = inputTestDivision ? itemCocFileName : outsourcingCocFileName;
+        String cocFileName = inputTestDivision.equals(PART) ? partCocFileName : outsourcingCocFileName;
 
         String cocFileUrl = s3Uploader.upload(cocFile, cocFileName);
         inputTestDetail.setCocFileUrl(cocFileUrl);
@@ -296,7 +306,7 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
             Long inputTestDetailId,
             boolean testReportDeleteYn,
             boolean cocDeleteYn,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     ) throws NotFoundException {
         InputTestDetail inputTestDetail = getInputTestDetailOrThrow(inputTestRequestId, inputTestDetailId, inputTestDivision);
         if (testReportDeleteYn) inputTestDetail.setTestReportFileUrl(null);
@@ -305,7 +315,7 @@ public class InputTestDetailServiceImpl implements InputTestDetailService {
     }
 
     // 검사정보 단일 조회 및 예외
-    private InputTestDetail getInputTestDetailOrThrow(Long inputTestRequestId, Long inputTestDetailId, boolean inputTestDivision) throws NotFoundException {
+    private InputTestDetail getInputTestDetailOrThrow(Long inputTestRequestId, Long inputTestDetailId, InputTestDivision inputTestDivision) throws NotFoundException {
         InputTestRequest inputTestRequest = inputTestRequestService.getInputTestRequestOrThrow(inputTestRequestId, inputTestDivision);
         return inputTestDetailRepo.findByInputTestRequestAndIdAndDeleteYnFalse(inputTestRequest, inputTestDetailId)
                 .orElseThrow(() -> new NotFoundException("inputTestDetail does not exist. " +

--- a/src/main/java/com/mes/mesBackend/service/impl/InputTestPerformanceServiceImpl.java
+++ b/src/main/java/com/mes/mesBackend/service/impl/InputTestPerformanceServiceImpl.java
@@ -2,6 +2,7 @@ package com.mes.mesBackend.service.impl;
 
 import com.mes.mesBackend.dto.response.InputTestPerformanceResponse;
 import com.mes.mesBackend.dto.response.InputTestScheduleResponse;
+import com.mes.mesBackend.entity.enumeration.InputTestDivision;
 import com.mes.mesBackend.entity.enumeration.TestType;
 import com.mes.mesBackend.repository.InputTestDetailRepository;
 import com.mes.mesBackend.service.InputTestPerformanceService;
@@ -14,6 +15,7 @@ import java.util.stream.Collectors;
 
 // 14-3. 검사실적 조회
 // 15-3. 검사실적 조회
+// 16-4. 검사 현황 조회
 @Service
 @RequiredArgsConstructor
 public class InputTestPerformanceServiceImpl implements InputTestPerformanceService {
@@ -28,16 +30,13 @@ public class InputTestPerformanceServiceImpl implements InputTestPerformanceServ
             String itemNoAndName,
             Long clientId,
             Long purchaseInputNo,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision,
+            TestType testType,
+            Long wareHouseId
     ) {
         return inputTestDetailRepo.findInputTestPerformanceResponseByCondition(
-                fromDate,
-                toDate,
-                itemNoAndName,
-                clientId,
-                purchaseInputNo,
-                inputTestDivision
-        ).stream().map(res -> res.division(inputTestDivision)).collect(Collectors.toList());
+                fromDate, toDate, itemNoAndName, clientId, purchaseInputNo, inputTestDivision, testType, wareHouseId)
+                .stream().map(res -> res.division(inputTestDivision)).collect(Collectors.toList());
     }
 
     // 검사대기 현황 조회
@@ -50,7 +49,7 @@ public class InputTestPerformanceServiceImpl implements InputTestPerformanceServ
             Long clientId,
             LocalDate fromDate,
             LocalDate toDate,
-            boolean inputTestDivision
+            InputTestDivision inputTestDivision
     ) {
         return inputTestDetailRepo.findInputTestScheduleResponsesByCondition(
                 wareHouseId,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   # jpa
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl


### PR DESCRIPTION
16-1. 검사의뢰등록 / 16-2. 검사등록 / 16-4. 검사 현황 조회 / 16-5. 검사대기 현황 api 구현되었습니다.
16-1. 검사의뢰 등록
완제품에 대해서만 검사의뢰 등록 가능 있음.
16-2. 검사 요청 정보
재고수량, 납기일자 필드 삭제
16-2. 검사 정보
검사성적서 파일 필드 삭제
16-4. 검사 현황 조회
검사창고, 납기일자 필드 삭제 / 폐기/반품수량 -> 부적합수량 변경
검색조건: 검사창고 -> 입고창고 변경
16-5. 검사 대기 현황
검사수량, 미검사수량, 납기일자 필드 삭제
변경사항
15-1. 검사의뢰등록
긴급여부, 검사성적서, coc 필드 삭제
15-2.  
검사요청정보: 재고수량, 긴급여부, 검사성적서, coc 필드 삭제
검사정보: 검사성적서 파일, coc 필드 삭제 및 검사성적서 파일 업로드, coc 파일 업로드 기능 없음.
15-3.
검사성적서, coc, 검사성적서 파일, coc 파일 필드 삭제
14-4
검사수량, 미검사수량 필드 삭제
15-4
검사수량, 미검사수량 필드 삭제